### PR TITLE
Program description namespace removal - revisited

### DIFF
--- a/programs/management/commands/import-catalog-data.py
+++ b/programs/management/commands/import-catalog-data.py
@@ -9,6 +9,7 @@ import sys
 from operator import attrgetter
 import xml.etree.ElementTree as ET
 from fuzzywuzzy import fuzz
+from bs4 import BeautifulSoup, NavigableString
 
 
 def clean_name(program_name):
@@ -274,24 +275,36 @@ class Command(BaseCommand):
 
         response = urllib2.urlopen(url)
         raw_data = response.read()
-        root = ET.fromstring(raw_data)
 
-        content = root.find('.//a:content', self.ns)
+        # Strip xmlns attributes to parse string to xml without namespaces
+        data = re.sub(' xmlns(?:\:[a-z]*)?="[^"]+"', '', raw_data)
+        root = BeautifulSoup(data, 'xml')
+        description_xml = root.find('content').encode_contents()
+        description_html = BeautifulSoup(description_xml, 'html.parser')
 
-        retval = ''
+        # Filter out invalid tags (replace them with span's)
+        tag_whitelist = [
+            'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+            'p', 'br', 'pre',
+            'table', 'tbody', 'thead', 'tr', 'td', 'a',
+            'ul', 'li', 'ol',
+            'b', 'em', 'i', 'strong', 'u'
+        ]
+        for match in description_html.descendants:
+            if match.name not in tag_whitelist and isinstance(match, NavigableString) == False:
+                match.name = 'span'
+                match.attrs = []
 
-        for el in content:
-            retval += ET.tostring(el, method='html')
+        # BS seems to have a hard time with doing this in-place, so perform
+        # a second loop to remove the garbage tags
+        for span_match in description_html.find_all('span'):
+            span_match.unwrap()
 
-        retval = retval.replace('<h:', '<').replace('</h:', '</')
+        # Strip newlines
+        nl_regex = re.compile(r'[\r\n\t]')
+        description_html = nl_regex.sub(' ', str(description_html))
 
-        retval = retval.replace(' xmlns:h="http://www.w3.org/1999/xhtml"', '')
-
-        regex = re.compile(r'[\r\n\t]')
-
-        retval = regex.sub(' ', retval)
-
-        return retval
+        return description_html
 
     def get_match_threshold(self, matchable_program, entry):
         # Base threshold score value. Increase base threshold

--- a/programs/management/commands/import-catalog-data.py
+++ b/programs/management/commands/import-catalog-data.py
@@ -282,7 +282,6 @@ class Command(BaseCommand):
         description_xml = root.find('content').encode_contents()
         description_html = BeautifulSoup(description_xml, 'html.parser')
 
-        # Filter out invalid tags (replace them with span's)
         tag_whitelist = [
             'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
             'p', 'br', 'pre',
@@ -290,6 +289,8 @@ class Command(BaseCommand):
             'ul', 'li', 'ol',
             'b', 'em', 'i', 'strong', 'u'
         ]
+
+        # Filter out tags not in our whitelist (replace them with span's)
         for match in description_html.descendants:
             if match.name not in tag_whitelist and isinstance(match, NavigableString) == False:
                 match.name = 'span'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Django==1.11.12
 django-filter==1.1.0
 djangorestframework==3.8.2
 fuzzywuzzy==0.16.0
+lxml==4.2.1
 MySQL-python==1.2.5
 pycodestyle==2.4.0
 python-Levenshtein==0.12.0


### PR DESCRIPTION
Updates `get_description()` to more broadly strip undesired namespaces from program catalog markup.

Specifically, this update strips `xmlns` attributes from the catalog xml before we attempt parsing it--doing so auto-magically strips namespace information from the parsed xml data (e.g. `<a:ul>` becomes `<ul>`).  From there, we assume the catalog description parts we care about are parseable html, and pass that parsed markup to BeautifulSoup to parse it as such.  We then loop through that html and remove non-whitelisted elements (because the catalog data includes vendor-specific markup, such as `<permalink>`).

I am open to suggestions on better ways of removing non-whitelisted elements (for the life of me, I couldn't get the `unwrap()` method to work properly in that first node loop), or for better ways of removing namespace information from the catalog data--what we're doing here feels a little hacky, but is also the cleanest way I can think of to strip those namespaces without having to know about each one ahead of time or using some crazy regex.