### PR TITLE
Program import updates

### DIFF
--- a/programs/fixtures/programs.json
+++ b/programs/fixtures/programs.json
@@ -192,5 +192,390 @@
             "skip": false,
             "required_fees": [1]
         }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 1,
+        "fields": {
+            "plan_code": "AD/PR-BA",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 2,
+        "fields": {
+            "plan_code": "COMCNF-BA",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 3,
+        "fields": {
+            "plan_code": "COMCNF-BA",
+            "subplan_code": "ZCOMCNFLBA",
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 4,
+        "fields": {
+            "plan_code": "COMM-MA",
+            "subplan_code": "BUSCOMM",
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 5,
+        "fields": {
+            "plan_code": "CORPCOMM",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 6,
+        "fields": {
+            "plan_code": "DIGIMED-BA",
+            "subplan_code": null,
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 7,
+        "fields": {
+            "plan_code": "DIGIMED-BA",
+            "subplan_code": "GAME DES",
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 8,
+        "fields": {
+            "plan_code": "DIGIMED-BA",
+            "subplan_code": "WEB DES",
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 9,
+        "fields": {
+            "plan_code": "DIGIMED-MA",
+            "subplan_code": null,
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 10,
+        "fields": {
+            "plan_code": "DIGIMED-MS",
+            "subplan_code": null,
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 11,
+        "fields": {
+            "plan_code": "FLM-BFA",
+            "subplan_code": null,
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 12,
+        "fields": {
+            "plan_code": "HISPMD-CRT",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 13,
+        "fields": {
+            "plan_code": "HLTHCM-CRT",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 14,
+        "fields": {
+            "plan_code": "HUMCOM-BA",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 15,
+        "fields": {
+            "plan_code": "HUMCOM-BA",
+            "subplan_code": "BUSPRFCOMM",
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 16,
+        "fields": {
+            "plan_code": "HUMCOM-BA",
+            "subplan_code": "GENHUMCOMM",
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 17,
+        "fields": {
+            "plan_code": "HUMCOM-BA",
+            "subplan_code": "INTPSNCOMM",
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 18,
+        "fields": {
+            "plan_code": "HUMCOM-BA",
+            "subplan_code": "SCLINACTV",
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 19,
+        "fields": {
+            "plan_code": "JOURNL-BA",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 20,
+        "fields": {
+            "plan_code": "JOURNL-BA",
+            "subplan_code": "ELECJOURNL",
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 21,
+        "fields": {
+            "plan_code": "JOURNL-BA",
+            "subplan_code": "PRDGJOURNL",
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 22,
+        "fields": {
+            "plan_code": "MOTPIC-BA",
+            "subplan_code": null,
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 23,
+        "fields": {
+            "plan_code": "MOTPIC-BA",
+            "subplan_code": "CINSTUDIES",
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 24,
+        "fields": {
+            "plan_code": "RADTV-BA",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 25,
+        "fields": {
+            "plan_code": "RADTV-BA",
+            "subplan_code": "PRODUCTN",
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 26,
+        "fields": {
+            "plan_code": "XCINSTUMIN",
+            "subplan_code": null,
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 27,
+        "fields": {
+            "plan_code": "XDIGMEDMIN",
+            "subplan_code": null,
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 28,
+        "fields": {
+            "plan_code": "XHMCOMMIN",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 29,
+        "fields": {
+            "plan_code": "XICOCMINOR",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 30,
+        "fields": {
+            "plan_code": "XJRNLSTDMI",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 31,
+        "fields": {
+            "plan_code": "XMAGJOUMIN",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 32,
+        "fields": {
+            "plan_code": "XMASSCOMMI",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 33,
+        "fields": {
+            "plan_code": "EMGMDA-MFA",
+            "subplan_code": null,
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 34,
+        "fields": {
+            "plan_code": "LTGNADVCRT",
+            "subplan_code": null,
+            "college": [
+                "CCIE"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 35,
+        "fields": {
+            "plan_code": "STRCOMMPHD",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
     }
 ]

--- a/programs/fixtures/programs.json
+++ b/programs/fixtures/programs.json
@@ -577,5 +577,49 @@
                 "COS"
             ]
         }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 36,
+        "fields": {
+            "plan_code": "DIGMED-MA",
+            "subplan_code": null,
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 37,
+        "fields": {
+            "plan_code": "DIGMED-MA",
+            "subplan_code": "VISLANGDM",
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 38,
+        "fields": {
+            "plan_code": "DIGMED-MS",
+            "subplan_code": null,
+            "college": [
+                "CAH"
+            ]
+        }
+    },
+    {
+        "model": "programs.collegeoverride",
+        "pk": 39,
+        "fields": {
+            "plan_code": "COMM-MA",
+            "subplan_code": null,
+            "college": [
+                "COS"
+            ]
+        }
     }
 ]

--- a/programs/management/commands/import-programs.py
+++ b/programs/management/commands/import-programs.py
@@ -47,11 +47,10 @@ class Command(BaseCommand):
         if mapping_path and not self.use_internal_mapping:
             mapping_resp = urllib2.urlopen(mapping_path)
             self.mappings = json.loads(mapping_resp.read())
+        elif self.use_internal_mapping:
+            self.mappings = CollegeOverride.objects.all()
         else:
             self.mappings = None
-
-        if self.use_internal_mapping:
-            self.mappings = CollegeOverride.objects.all()
 
         data = json.loads(response.read())
 

--- a/programs/management/commands/import-programs.py
+++ b/programs/management/commands/import-programs.py
@@ -16,6 +16,7 @@ class Command(BaseCommand):
         "PROF": "Professional"
     }
     mappings = {}
+    use_internal_mapping = False
 
     def add_arguments(self, parser):
         parser.add_argument('path', type=str, help='The url of the APIM API.')
@@ -28,17 +29,29 @@ class Command(BaseCommand):
             required=False
         )
 
+        parser.add_argument(
+            '--use-internal-mapping',
+            type=bool,
+            dest='use_internal_mapping',
+            help='Will use the college mappings within the search service data.',
+            required=False
+        )
+
     def handle(self, *args, **options):
         new_modified_date = timezone.now()
         path = options['path']
         mapping_path = options['mapping_path']
+        self.use_internal_mapping = options['use_internal_mapping']
         response = urllib2.urlopen(path)
 
-        if mapping_path:
+        if mapping_path and not self.use_internal_mapping:
             mapping_resp = urllib2.urlopen(mapping_path)
             self.mappings = json.loads(mapping_resp.read())
         else:
             self.mappings = None
+
+        if self.use_internal_mapping:
+            self.mappings = CollegeOverride.objects.all()
 
         data = json.loads(response.read())
 
@@ -111,12 +124,24 @@ class Command(BaseCommand):
         mapping = None
 
         if self.mappings:
-            mapping = [x for x in self.mappings['programs'] if x['plan_code'] == data['Plan'] and x['subplan_code'] == None]
+            if self.use_internal_mapping:
+                try:
+                    mapping = self.mappings.filter(plan_code=data['Plan'], subplan_code=None)
+                except:
+                    mapping = None
+            else:
+                mapping = [x for x in self.mappings['programs'] if x['plan_code'] == data['Plan'] and x['subplan_code'] == None]
 
         if mapping:
-            mapping = mapping[0]
-            data['College_Full'] = mapping['college']['name']
-            data['CollegeShort'] = mapping['college']['short_name']
+            if self.use_internal_mapping:
+                mapping = mapping[0]
+                data['College_Full'] = mapping.college.full_name
+                data['CollegeShort'] = mapping.college.short_name
+            else:
+                mapping = mapping[0]
+                data['College_Full'] = mapping['college']['name']
+                data['CollegeShort'] = mapping['college']['short_name']
+
 
         # Handle Colleges
         college, create = College.objects.get_or_create(

--- a/programs/models.py
+++ b/programs/models.py
@@ -50,11 +50,17 @@ class Degree(models.Model):
     def __unicode__(self):
         return self.name
 
+class CollegeManager(models.Manager):
+    def get_by_natural_key(self, short_name):
+        return self.get(short_name=short_name)
+
 
 class College(models.Model):
     """
     A college, including various names and urls
     """
+    objects = CollegeManager()
+
     full_name = models.CharField(max_length=255, null=False, blank=False)
     short_name = models.CharField(max_length=255, null=True, blank=False)
     college_url = models.URLField(null=True, blank=True)

--- a/programs/models.py
+++ b/programs/models.py
@@ -287,6 +287,37 @@ class CollegeOverride(models.Model):
     subplan_code = models.CharField(max_length=10, null=True, blank=True)
     college = models.ForeignKey(College, null=False, blank=False)
 
+    @property
+    def program(self):
+        program = Program.objects.filter(plan_code=self.plan_code, subplan_code=self.subplan_code)
+
+        if len(program):
+            return program[0]
+
+        return None
+
+    def __str__(self):
+        program = self.program
+
+        if program is not None:
+            return '{0} - {1} Override'.format(program.name, self.college.short_name)
+
+        if self.subplan_code is not None:
+            return '{0} {1} - {2} Override'.format(self.plan_code, self.subplan_code, self.college.short_name)
+
+        return '{0} - {1} Tuition Override'.format(self.plan_code, self.college.short_name)
+
+    def __unicode__(self):
+        program = self.program
+
+        if program is not None:
+            return '{0} - {1} Override'.format(program.name, self.college.short_name)
+
+        if self.subplan_code is not None:
+            return '{0} {1} - {2} Override'.format(self.plan_code, self.subplan_code, self.college.short_name)
+
+        return '{0} - {1} Tuition Override'.format(self.plan_code, self.college.short_name)
+
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)
 def create_auth_token(sender, instance=None, created=False, **kwargs):
     if created:


### PR DESCRIPTION
Enhancements:
* Added ability to override college assignment internally using the `CollegeOverride` model.
* Added logic to the program importer to use internal mappings if the `--use-internal-mapping` flag is set. The `--mapping-path` variable will be left in place for backwards compatibility.
* Updated the initial `programs.json` fixture to include the college mappings we currently have in our mappings file.
* Added `CollegeManager` class to make importing fixtures easier. The `get_by_natural_key` function makes it possible to add a college to a fixture using its `short_name` value instead of having to provide the `PK` which can vary from environment to environment.