### PR TITLE
Removal of stale catalog data

### DIFF
--- a/programs/management/commands/import-catalog-data.py
+++ b/programs/management/commands/import-catalog-data.py
@@ -195,7 +195,7 @@ class Command(BaseCommand):
         program_root = ET.fromstring(raw_data)
 
         for result in program_root.iter('result'):
-            if result.find('type') is not None:
+            if result.find('type') is not None and result.find('state').find('code').text == '1':
                 self.catalog_programs.append(
                     CatalogEntry(
                         result.find('id').text,


### PR DESCRIPTION
- Added check to `get_catalog_programs` to ensure we're only importing active catalog degree data
- Updated `match_programs` to always remove an existing catalog description on all programs before importing fresh data