### PR TITLE
Keywords fix

### DIFF
--- a/teledata/admin.py
+++ b/teledata/admin.py
@@ -38,4 +38,9 @@ class StaffAdmin(admin.ModelAdmin):
 
 @admin.register(Keyword)
 class KeywordAdmin(admin.ModelAdmin):
-    pass
+    search_fields = ('phrase',)
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == 'content_type':
+            kwargs['queryset'] = ContentType.objects.filter(app_label='teledata', model__in=['staff', 'organization', 'department'])
+        return super(KeywordAdmin, self).formfield_for_foreignkey(db_field, request, **kwargs)

--- a/teledata/models.py
+++ b/teledata/models.py
@@ -94,9 +94,9 @@ class Keyword(models.Model):
                 combined_obj = CombinedTeledata.objects.get(id=self.object_id, from_table=from_table)
                 combined_obj.keywords_combined.add(self)
         except CombinedTeledata.DoesNotExist:
-            logger.warn('Cannot create keywords_combined record for {0} - {1}. No record exists'.format(self.pharse, self.content_object.name))
+            logger.warn('Cannot create keywords_combined record for {0} - {1}. No record exists'.format(self.phrase, self.content_object.name))
         except:
-            logger.warn('Cannot create keywords_combined record for {0} - {1}. Possibly more than one object returned.'.format(self.pharse, self.content_object.name))
+            logger.warn('Cannot create keywords_combined record for {0} - {1}. Possibly more than one object returned.'.format(self.phrase, self.content_object.name))
 
     def delete(self):
         """

--- a/teledata/models.py
+++ b/teledata/models.py
@@ -73,6 +73,12 @@ class Keyword(models.Model):
     object_id = models.PositiveIntegerField()
     content_object = fields.GenericForeignKey('content_type', 'object_id')
 
+    def get_from_table(self, name):
+        if name == 'staff':
+            return name
+        elif name in ['department', 'organization']:
+            return "{0}s".format(name)
+
     def save(self):
         """
         Function that is called whenever
@@ -80,9 +86,13 @@ class Keyword(models.Model):
         """
         super(Keyword, self).save()
         try:
-            combined_obj = CombinedTeledata.objects.get(id=self.object_id)
+            from_table = self.get_from_table(self.content_type.name)
+
+            combined_obj = CombinedTeledata.objects.get(id=self.object_id, from_table=from_table)
             combined_obj.keywords_combined.add(self)
         except CombinedTeledata.DoesNotExist:
+            return
+        except:
             return
 
     def delete(self):
@@ -91,6 +101,8 @@ class Keyword(models.Model):
         the keyword is deleted
         """
         try:
+            from_table = self.get_from_table(self.content_type.name)
+
             combined_obj = CombinedTeledata.objects.get(id=self.object_id)
             combined_obj.keywords_combined.remove(self)
         except CombinedTeledata.DoesNotExist:

--- a/teledata/models.py
+++ b/teledata/models.py
@@ -79,6 +79,8 @@ class Keyword(models.Model):
         elif name in ['department', 'organization']:
             return "{0}s".format(name)
 
+        return None
+
     def save(self):
         """
         Function that is called whenever
@@ -88,12 +90,13 @@ class Keyword(models.Model):
         try:
             from_table = self.get_from_table(self.content_type.name)
 
-            combined_obj = CombinedTeledata.objects.get(id=self.object_id, from_table=from_table)
-            combined_obj.keywords_combined.add(self)
+            if from_table is not None:
+                combined_obj = CombinedTeledata.objects.get(id=self.object_id, from_table=from_table)
+                combined_obj.keywords_combined.add(self)
         except CombinedTeledata.DoesNotExist:
-            return
+            logger.warn('Cannot create keywords_combined record for {0} - {1}. No record exists'.format(self.pharse, self.content_object.name))
         except:
-            return
+            logger.warn('Cannot create keywords_combined record for {0} - {1}. Possibly more than one object returned.'.format(self.pharse, self.content_object.name))
 
     def delete(self):
         """
@@ -103,10 +106,13 @@ class Keyword(models.Model):
         try:
             from_table = self.get_from_table(self.content_type.name)
 
-            combined_obj = CombinedTeledata.objects.get(id=self.object_id)
-            combined_obj.keywords_combined.remove(self)
-        except CombinedTeledata.DoesNotExist:
+            if from_table is not None:
+                combined_obj = CombinedTeledata.objects.get(id=self.object_id, from_table=from_table)
+                combined_obj.keywords_combined.remove(self)
+        except:
+            logger.warn('Cannot remove keywords_combined record for {0} - {1}. Record may not exist.'.format(self.phrase, self.content_object.name))
             combined_obj = None
+
         super(Keyword, self).delete()
 
     def __unicode__(self):


### PR DESCRIPTION
Enhancements:
* Limited number of entries in the `Content type` field for keywords. The dropdown is limited now to the 3 content types that keywords actually effect.

Bug Fixes:
* Corrected bug that occurs when there is more than 1 object in the `CombinedTeledata` data with the same `object_id` - which is allowable and a pretty normal occurrence.