### PR TITLE
Hot Fix CORS and Pagination

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ autopep8==1.3.5
 beautifulsoup4==4.6.0
 contextlib2==0.6.0.post1
 coreschema==0.0.4
+django-cors-headers==3.0.2
 Django==1.11.23
 django-filter==1.1.0
 django-mysql==2.5.0

--- a/settings.py
+++ b/settings.py
@@ -49,6 +49,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'corsheaders.middleware.CorsMiddleware'
 ]
 
 ROOT_URLCONF = 'urls'

--- a/teledata/pagination.py
+++ b/teledata/pagination.py
@@ -1,0 +1,15 @@
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+from collections import OrderedDict
+
+class BackwardsCompatiblePagination(PageNumberPagination):
+    def get_paginated_response(self, data):
+        fields = OrderedDict()
+        fields['count'] = self.page.paginator.count
+        # Added for backwards compatibility
+        fields['resultCount'] = self.page.paginator.count
+        fields['next'] = self.get_next_link()
+        fields['previous'] = self.get_previous_link()
+        fields['results'] = data
+
+        return Response(fields)

--- a/teledata/views.py
+++ b/teledata/views.py
@@ -11,6 +11,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from teledata.models import *
 from teledata.serializers import *
 from teledata.filters import *
+from teledata.pagination import BackwardsCompatiblePagination
 
 from rest_framework.filters import OrderingFilter
 
@@ -47,6 +48,7 @@ class CombinedTeledataListView(generics.ListAPIView):
 class CombinedTeledataSearchView(CombinedTeledataListView):
     filter_class = CombinedTeledataFilter
     filter_backends = [DjangoFilterBackend,OrderingFilter]
+    pagination_class = BackwardsCompatiblePagination
     ordering_fields = ['id', 'score']
     ordering = ['-score']
 


### PR DESCRIPTION
Bug Fixes:
* Adds the `resultCount` count field to pagination on the CombinedTeledata - `/api/v1/teledata/` - view for backwards compatibility.
* Adds the CORS middleware package so that the feeds can be consumed by client-side applications.