### PR TITLE
CIP imports

### DIFF
--- a/programs/management/commands/import-programs.py
+++ b/programs/management/commands/import-programs.py
@@ -110,10 +110,12 @@ class Command(BaseCommand):
         try:
             program = Program.objects.get(plan_code=data['Plan'], subplan_code__isnull=True)
             program.name = unidecode(data['PlanName'])
+            program.cip_code = data['CIP']
             self.programs_updated += 1
         except Program.DoesNotExist:
             program = Program(
                 name=unidecode(data['PlanName']),
+                cip_code=data['CIP'],
                 plan_code=data['Plan']
             )
             self.programs_added += 1

--- a/programs/management/commands/import-programs.py
+++ b/programs/management/commands/import-programs.py
@@ -115,8 +115,8 @@ class Command(BaseCommand):
         except Program.DoesNotExist:
             program = Program(
                 name=unidecode(data['PlanName']),
-                cip_code=data['CIP'],
-                plan_code=data['Plan']
+                plan_code=data['Plan'],
+                cip_code=data['CIP']
             )
             self.programs_added += 1
 


### PR DESCRIPTION
Imports CIP codes for parent-level programs.  Resolves #52.

Note that we are intentionally _not_ adding CIPs to subplans because subplans don't have explicit CIP values in APIM's data, and there are instances where a parent plan's CIP may not be correct/accurate for its subplans.