### PR TITLE
Updated combined search view to order by id when no query is made

### DIFF
--- a/teledata/views.py
+++ b/teledata/views.py
@@ -50,10 +50,10 @@ class CombinedTeledataSearchView(CombinedTeledataListView):
     filter_backends = [DjangoFilterBackend,OrderingFilter]
     pagination_class = BackwardsCompatiblePagination
     ordering_fields = ['id', 'score']
-    ordering = ['-score']
 
     def get_queryset(self):
         if self.request.GET.get('search') is not None:
-            return CombinedTeledata.objects.search(self.request.GET.get('search'))
+            return CombinedTeledata.objects.search(self.request.GET.get('search')).order_by('-score')
         else:
-            return CombinedTeledata.objects.none()
+            # There is no score because the query isn't run. Order by id
+            return CombinedTeledata.objects.none().order_by('id')


### PR DESCRIPTION
Bug Fixes:
* Fixes #56. When no query is made, the order by logic fails because the `score` field is added dynamically. To fix this, the results are ordered by `score` only when a search query is made, and ordered by id when an empty set is being returned.