### PR TITLE
Simple feed

### DIFF
--- a/programs/serializers.py
+++ b/programs/serializers.py
@@ -350,7 +350,10 @@ class ProgramSerializer(DynamicFieldSetMixin, serializers.ModelSerializer):
 
     descriptions = ProgramDescriptionLinkedSerializer(many=True, read_only=False)
     profiles = ProgramProfileLinkedSerializer(many=True, read_only=False)
-    outcomes = serializers.SerializerMethodField()
+    outcomes = serializers.HyperlinkedIdentityField(
+        view_name='api.programs.outcomes',
+        lookup_field='id'
+    )
     projection_totals = serializers.SerializerMethodField()
     careers = serializers.SerializerMethodField()
 
@@ -366,19 +369,6 @@ class ProgramSerializer(DynamicFieldSetMixin, serializers.ModelSerializer):
 
     parent_program = RelatedProgramSerializer(many=False, read_only=True)
     subplans = RelatedProgramSerializer(many=True, read_only=True)
-
-    def get_outcomes(self, program):
-        all_outcome_data = program.outcomes.all()
-        latest_outcome_data = program.outcomes.order_by('-academic_year__code').first()
-        by_year_serializer = ProgramOutcomeStatSerializer(instance=all_outcome_data, many=True)
-        latest_serializer = ProgramOutcomeStatSerializer(instance=latest_outcome_data, many=False)
-
-        retval = {
-            'by_year': by_year_serializer.data,
-            'latest': latest_serializer.data
-        }
-
-        return retval
 
     def get_projections(self, program):
         projection_serializer = EmploymentProjectionSerializer(instance=program.current_projections, many=True)

--- a/programs/serializers.py
+++ b/programs/serializers.py
@@ -354,8 +354,14 @@ class ProgramSerializer(DynamicFieldSetMixin, serializers.ModelSerializer):
         view_name='api.programs.outcomes',
         lookup_field='id'
     )
-    projection_totals = serializers.SerializerMethodField()
-    careers = serializers.SerializerMethodField()
+    projection_totals = serializers.HyperlinkedIdentityField(
+        view_name='api.programs.projections',
+        lookup_field='id'
+    )
+    careers = serializers.HyperlinkedIdentityField(
+        view_name='api.programs.careers',
+        lookup_field='id'
+    )
 
     colleges = CollegeLinkSerializer(
         many=True,
@@ -376,24 +382,6 @@ class ProgramSerializer(DynamicFieldSetMixin, serializers.ModelSerializer):
 
     def get_careers(self, program):
         return program.careers
-
-    def get_projection_totals(self, program):
-        obj = program.current_projections.aggregate(
-            begin_employment=Sum('begin_employment'),
-            end_employment=Sum('end_employment'),
-            change=Sum('change'),
-            change_percentage=Avg('change_percentage'),
-            openings=Sum('openings')
-        )
-
-        first_projection = program.current_projections.first()
-
-        obj['begin_year'] = first_projection.report_year_begin if first_projection is not None else None
-        obj['end_year'] = first_projection.report_year_end if first_projection is not None else None
-
-        serializer = EmploymentProjectionTotalsSerializer(obj, many=False)
-        return serializer.data
-
 
     class Meta:
         fields = (

--- a/programs/serializers.py
+++ b/programs/serializers.py
@@ -376,13 +376,6 @@ class ProgramSerializer(DynamicFieldSetMixin, serializers.ModelSerializer):
     parent_program = RelatedProgramSerializer(many=False, read_only=True)
     subplans = RelatedProgramSerializer(many=True, read_only=True)
 
-    def get_projections(self, program):
-        projection_serializer = EmploymentProjectionSerializer(instance=program.current_projections, many=True)
-        return projection_serializer.data
-
-    def get_careers(self, program):
-        return program.careers
-
     class Meta:
         fields = (
             'id',

--- a/programs/urls.py
+++ b/programs/urls.py
@@ -15,6 +15,11 @@ urlpatterns = [
         ProgramDetailView.as_view(),
         name='api.programs.detail'
         ),
+    url(
+        r'programs/(?P<id>\d+)/outcomes/$',
+        ProgramOutcomeView.as_view(),
+        name='api.programs.outcomes'
+        ),
     url(r'^programs/search/$',
         ProgramSearchView.as_view(),
         name='api.programs.search'

--- a/programs/urls.py
+++ b/programs/urls.py
@@ -16,9 +16,19 @@ urlpatterns = [
         name='api.programs.detail'
         ),
     url(
-        r'programs/(?P<id>\d+)/outcomes/$',
+        r'^programs/(?P<id>\d+)/outcomes/$',
         ProgramOutcomeView.as_view(),
         name='api.programs.outcomes'
+        ),
+    url(
+        r'^programs/(?P<id>\d+)/projections/$',
+        ProgramProjectionTotalsView.as_view(),
+        name='api.programs.projections'
+        ),
+    url(
+        r'^programs/(?P<id>\d+)/careers/$',
+        ProgramCareerView.as_view(),
+        name='api.programs.careers'
         ),
     url(r'^programs/search/$',
         ProgramSearchView.as_view(),

--- a/programs/views.py
+++ b/programs/views.py
@@ -163,3 +163,16 @@ class CIPDetailView(generics.RetrieveAPIView):
         version = self.kwargs['version'] if 'version' in self.kwargs.keys() else settings.CIP_CURRENT_VERSION
         code = str(self.kwargs['code'])
         return CIP.objects.get(version=version, code=code)
+
+class ProgramOutcomeView(APIView):
+    def get(self, request, format=None, **kwargs):
+        program = Program.objects.get(id=kwargs['id'])
+        outcomes = program.outcomes.all()
+        latest = program.outcomes.order_by('-academic_year__code').first()
+
+        retval = {
+            'by_year': ProgramOutcomeStatSerializer(instance=outcomes, many=True).data,
+            'latest': ProgramOutcomeStatSerializer(instance=latest, many=False).data
+        }
+
+        return Response(retval)

--- a/programs/views.py
+++ b/programs/views.py
@@ -176,3 +176,29 @@ class ProgramOutcomeView(APIView):
         }
 
         return Response(retval)
+
+class ProgramProjectionTotalsView(APIView):
+    def get(request, format=None, **kwargs):
+        program = Program.objects.get(id=kwargs['id'])
+
+        obj = program.current_projections.aggregate(
+            begin_employment=Sum('begin_employment'),
+            end_employment=Sum('end_employment'),
+            change=Sum('change'),
+            change_percentage=Avg('change_percentage'),
+            openings=Sum('openings')
+        )
+
+        first_projection = program.current_projections.first()
+
+        obj['begin_year'] = first_projection.report_year_begin if first_projection is not None else None
+        obj['end_year'] = first_projection.report_year_end if first_projection is not None else None
+
+        serializer = EmploymentProjectionTotalsSerializer(obj, many=False)
+        return Response(serializer.data)
+
+class ProgramCareerView(APIView):
+    def get(request, format=None, **kwargs):
+        program = Program.objects.get(id=kwargs['id'])
+
+        return Response(program.careers.all())


### PR DESCRIPTION
Enhancements:
* Removes outcomes, projection totals and careers from the program serializer and instead creates separate feeds for each which can be accessed underneath the program detail view, i.e. `/api/v1/programs/<id>/outcomes/`.
* A link to each view has been added to the programs serializer.