### PR TITLE
Tag importer

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -11,4 +11,4 @@ class LowercaseCharField(models.CharField):
         super(LowercaseCharField, self).__init__(*args, **kwargs)
 
     def get_prep_value(self, value):
-        return str(value).lower()
+        return value.lower()

--- a/images/management/commands/import-tandemvault-images.py
+++ b/images/management/commands/import-tandemvault-images.py
@@ -485,19 +485,23 @@ Script executed in {6}
     Deletes Image objects sourced from Tandem Vault that are no
     longer present in Tandem Vault, and deletes ImageTags that
     are not assigned to any Images.
+
+    ** NOTE: stale tag deletion is commented out for now, until
+    we can create a complete set of image + Tandem Vault tag data
+    in the search service
     '''
     def delete_stale(self):
         stale_images = Image.objects.filter(
             last_imported__lt=self.imported,
             source=self.source
         )
-        stale_tags = ImageTag.objects.filter(images=None)
+        # stale_tags = ImageTag.objects.filter(images=None)
 
         self.images_deleted = stale_images.count()
-        self.tags_deleted = stale_tags.count()
+        # self.tags_deleted = stale_tags.count()
 
         stale_images.delete()
-        stale_tags.delete()
+        # stale_tags.delete()
 
 
 '''

--- a/images/management/commands/import-tandemvault-images.py
+++ b/images/management/commands/import-tandemvault-images.py
@@ -62,13 +62,6 @@ class Command(BaseCommand):
             required=False
         ),
         parser.add_argument(
-            '--tandemvault-tags-csv-url',
-            type=str,
-            help='URL that points to a CSV containing existing tag and synonym information from Tandem Vault',
-            dest='tandemvault-tags-csv-url',
-            required=False
-        ),
-        parser.add_argument(
             '--assign-tags',
             type=str,
             help='Specify what images, if any, should be processed with AWS\'s Rekognition services to generate image tags.',
@@ -89,7 +82,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.tandemvault_domain = options['tandemvault-domain'].replace('http://', '').replace('https://', '')
         self.tandemvault_api_key = options['tandemvault-api-key']
-        self.tandemvault_tags_csv = options['tandemvault-tags-csv-url']
         self.aws_access_key = settings.AWS_ACCESS_KEY
         self.aws_secret_key = settings.AWS_SECRET_KEY
         self.aws_region = settings.AWS_REGION
@@ -157,10 +149,6 @@ class Command(BaseCommand):
                 logging.error('ERROR establishing client: %s' % e)
                 return
 
-        # If a CSV of existing tags was provided, process it
-        if self.tandemvault_tags_csv:
-            self.load_tandemvault_tags()
-
         # Fetch + loop through all Tandem Vault API results
         self.process_images()
 
@@ -176,14 +164,6 @@ class Command(BaseCommand):
         self.print_stats()
 
         return
-
-    '''
-    Pre-load a CSV of Tandem Vault tags + synonyms.
-
-    TODO
-    '''
-    def load_tandemvault_tags():
-        pass
 
     '''
     The main image processing function that executes all API

--- a/images/management/commands/import-tandemvault-tags.py
+++ b/images/management/commands/import-tandemvault-tags.py
@@ -5,6 +5,7 @@ import csv
 import datetime
 import json
 import logging
+import mimetypes
 import timeit
 
 from progress.bar import Bar
@@ -14,13 +15,15 @@ from unidecode import unidecode
 class Command(BaseCommand):
     help = 'Imports all existing image tags from UCF\'s Tandem Vault instance.'
 
-    progress_bar = Bar('Processing')
-    source       = 'Tandem Vault'
-    tags         = []
-    tag_count    = 0
-    tags_created = 0
-    tags_updated = 0
-    tags_deleted = 0
+    progress_bar      = Bar('Processing')
+    source            = 'Tandem Vault'
+    tags              = []
+    tag_count         = 0
+    tags_created      = 0
+    tags_updated      = 0
+    tags_deleted      = 0
+    tags_skipped      = 0
+    synonyms_assigned = 0
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -69,11 +72,26 @@ class Command(BaseCommand):
     Load a CSV of Tandem Vault tags + synonyms.
     '''
     def load_tandemvault_tags(self):
+        # The csv lib will happily process pretty much any file
+        # you throw at it; do some really rudimentary checking
+        # against the file name before continuing:
+        try:
+            mime = mimetypes.guess_type(self.tandemvault_tags_csv.name)[0]
+        except Exception, e:
+            logging.error(
+                '\n ERROR reading CSV: couldn\'t verify mimetype of file')
+            return
+
+        if mime != 'text/csv':
+            logging.error(
+                '\n ERROR reading CSV: expected file with mimetype "text/csv"; got "%s"' % mime)
+            return
+
         try:
             csv_reader = csv.DictReader(self.tandemvault_tags_csv)
-        except csv.Error:
+        except csv.Error, e:
             logging.error(
-                '\n ERROR reading CSV: CSV does not have valid headers or is malformed.')
+                '\n ERROR reading CSV: %s' % e)
             return
 
         for row in csv_reader:
@@ -90,6 +108,7 @@ class Command(BaseCommand):
             # Empty tags can exist in this data for whatever reason;
             # skip them if present
             if not name:
+                self.tags_skipped += 1
                 continue
 
             synonyms = filter(None, [self.clean_tag_name(synonym) for synonym in json.loads(tandemvault_tag['synonym_names'])])
@@ -109,6 +128,7 @@ class Command(BaseCommand):
             for synonym in synonyms:
                 s, created = ImageTag.objects.get_or_create(name=synonym, source=self.source)
                 tag.synonyms.add(s)
+                self.synonyms_assigned += 1
 
             tag.save()
 
@@ -129,17 +149,22 @@ class Command(BaseCommand):
     '''
     def print_stats(self):
         stats = """
-Finished import of Tandem Vault image tags.
+Finished import of {0} Tandem Vault image tags.
 
-Created: {0}
-Updated: {1}
-Deleted: {2}
+Created: {1}
+Updated: {2}
+Deleted: {3}
+Skipped: {4}
+Synonyms assigned: {5}
 
-Script executed in {3}
+Script executed in {6}
         """.format(
+            self.tag_count,
             self.tags_created,
             self.tags_updated,
             self.tags_deleted,
+            self.tags_skipped,
+            self.synonyms_assigned,
             self.exec_time
         )
 

--- a/images/management/commands/import-tandemvault-tags.py
+++ b/images/management/commands/import-tandemvault-tags.py
@@ -29,10 +29,19 @@ class Command(BaseCommand):
             help='CSV file containing existing tag and synonym information from Tandem Vault',
             dest='file',
             required=True
+        ),
+        parser.add_argument(
+            '--delete-stale',
+            type=bool,
+            help='Whether or not stale tags (tags not assigned to any Images) should be deleted.',
+            dest='delete-stale',
+            default=False,
+            required=False
         )
 
     def handle(self, *args, **options):
         self.tandemvault_tags_csv = options['file']
+        self.do_delete_stale = options['delete-stale']
 
         # Start a timer for the bulk of the script
         self.exec_time = 0
@@ -43,7 +52,8 @@ class Command(BaseCommand):
         self.process_tandemvault_tags()
 
         # Delete stale Tandem Vault image tags
-        #self.delete_stale()
+        if self.do_delete_stale:
+            self.delete_stale()
 
         # Stop timer
         self.exec_end = timeit.default_timer()
@@ -136,9 +146,8 @@ Script executed in {3}
         print(stats)
 
     '''
-    Deletes Image objects sourced from Tandem Vault that are no
-    longer present in Tandem Vault, and deletes ImageTags sources
-    from Tandem Vault that are not assigned to any Images.
+    Deletes ImageTags sourced from Tandem Vault
+    that are not assigned to any Images.
     '''
     def delete_stale(self):
         stale_tags = ImageTag.objects.filter(images=None, source=self.source)

--- a/images/management/commands/import-tandemvault-tags.py
+++ b/images/management/commands/import-tandemvault-tags.py
@@ -1,0 +1,92 @@
+from django.core.management.base import BaseCommand
+from images.models import *
+
+import logging
+import timeit
+import datetime
+
+import requests
+from progress.bar import Bar
+
+
+class Command(BaseCommand):
+    help = 'Imports all existing image tags from UCF\'s Tandem Vault instance.'
+
+    progress_bar = Bar('Processing')
+    source       = 'Tandem Vault'
+    tags_created = 0
+    tags_updated = 0
+    tags_deleted = 0
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--tandemvault-tags-csv-url',
+            type=str,
+            help='URL that points to a CSV containing existing tag and synonym information from Tandem Vault',
+            dest='tandemvault-tags-csv-url',
+            required=True
+        )
+
+    def handle(self, *args, **options):
+        self.tandemvault_tags_csv = options['tandemvault-tags-csv-url']
+
+        # Start a timer for the bulk of the script
+        self.exec_time = 0
+        self.exec_start = timeit.default_timer()
+
+        # Process the CSV
+        self.load_tandemvault_tags()
+
+        # Delete stale Tandem Vault image tags
+        self.delete_stale()
+
+        # Stop timer
+        self.exec_end = timeit.default_timer()
+        self.exec_time = datetime.timedelta(seconds=self.exec_end - self.exec_start)
+
+        # Print the results
+        self.progress_bar.finish()
+        self.print_stats()
+
+        return
+
+    '''
+    Pre-load a CSV of Tandem Vault tags + synonyms.
+
+    TODO
+    '''
+    def load_tandemvault_tags():
+        pass
+
+    '''
+    Displays information about the import.
+    '''
+    def print_stats(self):
+        stats = """
+Finished import of Tandem Vault image tags.
+
+Created: {0}
+Updated: {1}
+Deleted: {2}
+
+Script executed in {3}
+        """.format(
+            self.tags_created,
+            self.tags_updated,
+            self.tags_deleted,
+            self.exec_time
+        )
+
+        print(stats)
+
+    '''
+    Deletes Image objects sourced from Tandem Vault that are no
+    longer present in Tandem Vault, and deletes ImageTags sources
+    from Tandem Vault that are not assigned to any Images.
+    '''
+    def delete_stale(self):
+        stale_tags = ImageTag.objects.filter(images=None, source=self.source)
+
+        self.tags_deleted = stale_tags.count()
+
+        stale_tags.delete()


### PR DESCRIPTION
Added an importer for existing tags and their synonyms from Tandem Vault.  Tag data must be downloaded manually from the Tandem Vault admin and passed to the import command.

Resolves #81 