### PR TITLE
Ensure LowercaseCharField get_prep_value() always returns a string

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -11,4 +11,5 @@ class LowercaseCharField(models.CharField):
         super(LowercaseCharField, self).__init__(*args, **kwargs)
 
     def get_prep_value(self, value):
+        value = super(LowercaseCharField, self).get_prep_value(value)
         return value.lower()

--- a/core/models.py
+++ b/core/models.py
@@ -12,4 +12,6 @@ class LowercaseCharField(models.CharField):
 
     def get_prep_value(self, value):
         value = super(LowercaseCharField, self).get_prep_value(value)
-        return value.lower()
+        if value is not None:
+            return value.lower()
+        return ''


### PR DESCRIPTION
Fixes a bug with migrations not getting applied correctly.