### PR TITLE
Stale image/tag object deletion

### DIFF
--- a/images/management/commands/import-tandemvault-images.py
+++ b/images/management/commands/import-tandemvault-images.py
@@ -249,7 +249,7 @@ class Command(BaseCommand):
         parser.add_argument(
             '--delete-stale-tags',
             type=bool,
-            help='If enabled, existing ImageTag objects that have no assigned Images or related synonyms with assigned Images will be removed.',
+            help='If enabled, existing ImageTag objects that have no assigned Images will be removed (but respects synonym relationships, one level deep).',
             dest='delete-stale-tags',
             default=False,
             required=False

--- a/images/management/commands/import-tandemvault-images.py
+++ b/images/management/commands/import-tandemvault-images.py
@@ -239,17 +239,17 @@ class Command(BaseCommand):
             required=False
         )
         parser.add_argument(
-            '--delete-stale-images',
-            type=bool,
-            help='If enabled, existing Image objects that are not present in the retrieved Tandem Vault data will be removed.',
-            dest='delete-stale-images',
-            default=True,
+            '--preserve-stale-images',
+            help='If enabled, existing Image objects that are not present in the retrieved Tandem Vault data will *not* be deleted.',
+            action='store_true',
+            dest='preserve-stale-images',
+            default=False,
             required=False
         )
         parser.add_argument(
             '--delete-stale-tags',
-            type=bool,
-            help='If enabled, existing ImageTag objects that have no assigned Images will be removed (but respects synonym relationships, one level deep).',
+            help='If enabled, existing ImageTag objects that have no assigned Images will be deleted (but synonym relationships one level deep will be respected).',
+            action='store_true',
             dest='delete-stale-tags',
             default=False,
             required=False
@@ -275,7 +275,7 @@ class Command(BaseCommand):
         self.assign_tags = options['assign-tags']
         self.tag_confidence_threshold = options['tag-confidence-threshold']
         self.number_threads = options['number-threads']
-        self.delete_stale_images = options['delete-stale-images']
+        self.preserve_stale_images = options['preserve-stale-images']
         self.delete_stale_tags = options['delete-stale-tags']
         self.loglevel = options['loglevel']
 
@@ -721,10 +721,10 @@ Script executed in {6}
         longer present in Tandem Vault, and deletes ImageTags that
         are not assigned to any Images.
 
-        Uses the --delete-stale-images and --delete-stale-tags flags
+        Uses the --preserve-stale-images and --delete-stale-tags flags
         to determine whether stale objects should be deleted.
         """
-        if self.delete_stale_images:
+        if not self.preserve_stale_images:
             stale_images = Image.objects.filter(
                 last_imported__lt=self.imported,
                 source=self.source

--- a/images/management/commands/import-tandemvault-tags.py
+++ b/images/management/commands/import-tandemvault-tags.py
@@ -151,10 +151,10 @@ Finished import of {0} Tandem Vault image tags.
 
 Created: {1}
 Updated: {2}
-Skipped: {4}
-Synonyms assigned: {5}
+Skipped: {3}
+Synonyms assigned: {4}
 
-Script executed in {6}
+Script executed in {5}
         """.format(
             self.tag_count,
             self.tags_created,

--- a/images/management/commands/import-tandemvault-tags.py
+++ b/images/management/commands/import-tandemvault-tags.py
@@ -21,7 +21,6 @@ class Command(BaseCommand):
     tag_count         = 0
     tags_created      = 0
     tags_updated      = 0
-    tags_deleted      = 0
     tags_skipped      = 0
     synonyms_assigned = 0
 
@@ -32,19 +31,10 @@ class Command(BaseCommand):
             help='CSV file containing existing tag and synonym information from Tandem Vault',
             dest='file',
             required=True
-        ),
-        parser.add_argument(
-            '--delete-stale',
-            type=bool,
-            help='Whether or not stale tags (tags not assigned to any Images) should be deleted.',
-            dest='delete-stale',
-            default=False,
-            required=False
         )
 
     def handle(self, *args, **options):
         self.tandemvault_tags_csv = options['file']
-        self.do_delete_stale = options['delete-stale']
 
         # Start a timer for the bulk of the script
         self.exec_time = 0
@@ -53,10 +43,6 @@ class Command(BaseCommand):
         # Process the CSV
         self.load_tandemvault_tags()
         self.process_tandemvault_tags()
-
-        # Delete stale Tandem Vault image tags
-        if self.do_delete_stale:
-            self.delete_stale()
 
         # Stop timer
         self.exec_end = timeit.default_timer()
@@ -165,7 +151,6 @@ Finished import of {0} Tandem Vault image tags.
 
 Created: {1}
 Updated: {2}
-Deleted: {3}
 Skipped: {4}
 Synonyms assigned: {5}
 
@@ -174,21 +159,9 @@ Script executed in {6}
             self.tag_count,
             self.tags_created,
             self.tags_updated,
-            self.tags_deleted,
             self.tags_skipped,
             self.synonyms_assigned,
             self.exec_time
         )
 
         print(stats)
-
-    '''
-    Deletes ImageTags sourced from Tandem Vault
-    that are not assigned to any Images.
-    '''
-    def delete_stale(self):
-        stale_tags = ImageTag.objects.filter(images=None, source=self.source)
-
-        self.tags_deleted = stale_tags.count()
-
-        stale_tags.delete()


### PR DESCRIPTION
- Added argument for allowing stale images to be preserved during the image import (by default, existing Image objects not present in the retrieved Tandem Vault data will be *deleted*).
- Added argument that deletes stale tags after the import finishes (by default, tags assigned to an image, and synonyms whose root tag is assigned to an image are *preserved*)
- Removed option to delete tags during the Tandem Vault tag importer, since we only ever want to delete stale tag data after images have been processed

Resolves #99 