### PR TITLE
Image importer cleanup

### DIFF
--- a/images/management/commands/import-tandemvault-images.py
+++ b/images/management/commands/import-tandemvault-images.py
@@ -483,9 +483,9 @@ class Command(BaseCommand):
         self.process_tandemvault_assets_page(1)
 
         # Loop through the other pages of results:
-        # if self.tandemvault_page_count > 1:
-            # for page in range(2, self.tandemvault_page_count):
-                # self.process_tandemvault_assets_page(page)
+        if self.tandemvault_page_count > 1:
+            for page in range(2, self.tandemvault_page_count):
+                self.process_tandemvault_assets_page(page)
 
     def process_tags(self, images):
         """

--- a/images/management/commands/import-tandemvault-images.py
+++ b/images/management/commands/import-tandemvault-images.py
@@ -349,7 +349,6 @@ class Command(BaseCommand):
 
         # Set logging level
         logging.basicConfig(stream=sys.stdout, level=self.loglevel)
-        logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
 
         if (
             not self.tandemvault_admin_api_key

--- a/images/management/commands/import-tandemvault-images.py
+++ b/images/management/commands/import-tandemvault-images.py
@@ -177,14 +177,17 @@ class Command(BaseCommand):
     source = 'Tandem Vault'
     auto_tag_source = 'AWS Rekognition'
     auto_tag_blacklist = [
-        'human',
+        'accessory',
+        'accessories',
         'apparel',
         'clothing',
-        'skin',
         'dating',
+        'furniture',
+        'human',
+        'mammal'
         'photo',
         'photography',
-        'mammal'
+        'skin'
     ]
     auto_tag_translations = {
         'american football': 'football'

--- a/images/management/commands/import-tandemvault-tags.py
+++ b/images/management/commands/import-tandemvault-tags.py
@@ -28,7 +28,10 @@ class Command(BaseCommand):
         parser.add_argument(
             '--file',
             type=file,
-            help='CSV file containing existing tag and synonym information from Tandem Vault',
+            help='''\
+            CSV file containing existing tag and synonym information
+            from Tandem Vault
+            ''',
             dest='file',
             required=True
         )

--- a/images/management/commands/import-tandemvault-tags.py
+++ b/images/management/commands/import-tandemvault-tags.py
@@ -15,13 +15,13 @@ from unidecode import unidecode
 class Command(BaseCommand):
     help = 'Imports all existing image tags from UCF\'s Tandem Vault instance.'
 
-    progress_bar      = Bar('Processing')
-    source            = 'Tandem Vault'
-    tags              = []
-    tag_count         = 0
-    tags_created      = 0
-    tags_updated      = 0
-    tags_skipped      = 0
+    progress_bar = Bar('Processing')
+    source = 'Tandem Vault'
+    tags = []
+    tag_count = 0
+    tags_created = 0
+    tags_updated = 0
+    tags_skipped = 0
     synonyms_assigned = 0
 
     def add_arguments(self, parser):
@@ -46,7 +46,9 @@ class Command(BaseCommand):
 
         # Stop timer
         self.exec_end = timeit.default_timer()
-        self.exec_time = datetime.timedelta(seconds=self.exec_end - self.exec_start)
+        self.exec_time = datetime.timedelta(
+            seconds=self.exec_end - self.exec_start
+        )
 
         # Print the results
         self.progress_bar.finish()

--- a/images/management/commands/import-tandemvault-tags.py
+++ b/images/management/commands/import-tandemvault-tags.py
@@ -70,19 +70,27 @@ class Command(BaseCommand):
             mime = mimetypes.guess_type(self.tandemvault_tags_csv.name)[0]
         except Exception, e:
             logging.error(
-                '\n ERROR reading CSV: couldn\'t verify mimetype of file')
+                '\nError reading CSV: couldn\'t verify mimetype of file'
+            )
             return
 
         if mime != 'text/csv':
             logging.error(
-                '\n ERROR reading CSV: expected file with mimetype "text/csv"; got "%s"' % mime)
+                (
+                    '\nError reading CSV: expected file with mimetype '
+                    '"text/csv"; got "{0}"'
+                )
+                .format(mime)
+            )
             return
 
         try:
             csv_reader = csv.DictReader(self.tandemvault_tags_csv)
         except csv.Error, e:
             logging.error(
-                '\n ERROR reading CSV: %s' % e)
+                '\nError reading CSV: {0}'
+                .format(e)
+            )
             return
 
         for row in csv_reader:
@@ -151,7 +159,7 @@ class Command(BaseCommand):
     Displays information about the import.
     '''
     def print_stats(self):
-        stats = """
+        stats = '''\
 Finished import of {0} Tandem Vault image tags.
 
 Created: {1}
@@ -160,7 +168,7 @@ Skipped: {3}
 Synonyms assigned: {4}
 
 Script executed in {5}
-        """.format(
+        '''.format(
             self.tag_count,
             self.tags_created,
             self.tags_updated,


### PR DESCRIPTION
- Various linter improvements and updates to string printing and formatting to be more python3-ready
- Added a few terms to the image auto-tagging blacklist and alphabetized it
- Un-commented out the main pagination loop in the image importer's `process_images()`, so that we can perform an actual full import