### PR TITLE
CORS Fix

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     'rest_framework.authtoken',
     'drf_dynamic_fields',
     'django_mysql',
+    'corsheaders',
 
     # Local
     'programs',
@@ -46,12 +47,12 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'corsheaders.middleware.CorsMiddleware'
 ]
 
 ROOT_URLCONF = 'urls'


### PR DESCRIPTION
Added the `corsheaders` module to the installed apps list and reordered the middleware loading order.

This should allow CORS headers to be properly set again.