### PR TITLE
Single profile field

### DIFF
--- a/programs/management/commands/process-profiles.py
+++ b/programs/management/commands/process-profiles.py
@@ -1,0 +1,68 @@
+from django.core.management.base import BaseCommand, CommandError
+from programs.models import *
+
+import settings
+from tabulate import tabulate
+
+class Command(BaseCommand):
+    help = """
+Processes program profiles and sets the primary profile
+based on the values set in PROGRAM_PROFILE constant in
+the settings_local.py file.
+    """
+    programs_processed = 0
+    programs_updated = 0
+    programs_unable = 0
+    programs_no_change = 0
+    programs_missing = 0
+
+    def handle(self, *args, **options):
+        """
+        Handles the process-profiles command.
+        """
+        self.update_programs()
+        self.print_stats()
+
+    def update_programs(self):
+        """
+        Handles updating the programs
+        """
+        programs = Program.objects.all()
+
+        for program in programs:
+            self.programs_processed += 1
+
+            profile_type = program.primary_profile_type
+
+            if profile_type == None:
+                self.programs_unable += 1
+                continue
+
+            profile = program.profiles.filter(profile_type=profile_type).first()
+
+            if profile is not None:
+                if profile.primary == False:
+                    profile.primary = True
+                    profile.save()
+                    program.profiles.exclude(pk=profile.pk).update(primary=False)
+                    self.programs_updated += 1
+                else:
+                    self.programs_no_change += 1
+            else:
+                self.programs_missing += 1
+
+    def print_stats(self):
+        results = [
+            ("Programs Processed", self.programs_processed),
+            ("Programs Updated", self.programs_updated),
+            ("Programs With No Changes", self.programs_no_change),
+            ("Programs Unable to be Updated", self.programs_unable),
+            ("Programs With Missing Profile", self.programs_missing)
+        ]
+
+        self.stdout.write('''
+Complete!
+
+        ''')
+
+        self.stdout.write(tabulate(results, tablefmt='grid'), ending='\n\n')

--- a/programs/models.py
+++ b/programs/models.py
@@ -346,8 +346,8 @@ class Program(models.Model):
         for rule in rules:
             conditions_met = False
 
-            # If there are no conditions, then they conditions are met
-            # This should only apply to the 'default' assignment
+            # If there are no conditions, then the conditions are met.
+            # This should only apply to the 'default' assignment.
             if len(rule['conditions']) < 1:
                 conditions_met = True
 

--- a/programs/models.py
+++ b/programs/models.py
@@ -346,6 +346,8 @@ class Program(models.Model):
         for rule in rules:
             conditions_met = False
 
+            # If there are no conditions, then they conditions are met
+            # This should only apply to the 'default' assignment
             if len(rule['conditions']) < 1:
                 conditions_met = True
 

--- a/programs/serializers.py
+++ b/programs/serializers.py
@@ -384,7 +384,7 @@ class ProgramSerializer(DynamicFieldSetMixin, serializers.ModelSerializer):
             'online',
             'has_online',
             'profiles',
-            'profile',
+            'primary_profile_url',
             'plan_code',
             'subplan_code',
             'catalog_url',

--- a/programs/serializers.py
+++ b/programs/serializers.py
@@ -384,6 +384,7 @@ class ProgramSerializer(DynamicFieldSetMixin, serializers.ModelSerializer):
             'online',
             'has_online',
             'profiles',
+            'profile',
             'plan_code',
             'subplan_code',
             'catalog_url',

--- a/settings_local.tmpl.py
+++ b/settings_local.tmpl.py
@@ -153,7 +153,7 @@ PROGRAM_PROFILE = [
         'value': 'Online'
     },
     {
-        'conditionals': []
+        'conditionals': [],
         'value': 'Main Site'
     }
 ]

--- a/settings_local.tmpl.py
+++ b/settings_local.tmpl.py
@@ -141,6 +141,7 @@ AWS_SECRET_KEY = ''
 # The region name to use when accessing Rekognition.
 AWS_REGION = 'us-east-1'
 
+# Conditional outcomes for setting the default program profile
 PROGRAM_PROFILE = [
     {
         'conditionals': [

--- a/settings_local.tmpl.py
+++ b/settings_local.tmpl.py
@@ -140,3 +140,19 @@ AWS_SECRET_KEY = ''
 
 # The region name to use when accessing Rekognition.
 AWS_REGION = 'us-east-1'
+
+PROGRAM_PROFILE = [
+    {
+        'conditionals': [
+            {
+                'field': 'online',
+                'value': True
+            }
+        ],
+        'value': 'Online'
+    },
+    {
+        'conditionals': []
+        'value': 'Main Site'
+    }
+]

--- a/settings_local.tmpl.py
+++ b/settings_local.tmpl.py
@@ -144,7 +144,7 @@ AWS_REGION = 'us-east-1'
 # Conditional outcomes for setting the default program profile
 PROGRAM_PROFILE = [
     {
-        'conditionals': [
+        'conditions': [
             {
                 'field': 'online',
                 'value': True
@@ -153,7 +153,7 @@ PROGRAM_PROFILE = [
         'value': 'Online'
     },
     {
-        'conditionals': [],
+        'conditions': [],
         'value': 'Main Site'
     }
 ]


### PR DESCRIPTION
* Adds a `profile` field, which provides a scalar value for a program profile.
* The `profile` field is populated with the URL of either the `primary` profile, the primary profile has determined by the `PROGRAM_PROFILE` logic, or the URL of the primary `ProgramProfileType` as determined by the same logic if there is no profile.
* Adds a process for assigning the `primary` attribute on profiles based on the `PROGRAM_PROFILE` logic.