### PR TITLE
Program import hotfix

### DIFF
--- a/programs/management/commands/import-programs.py
+++ b/programs/management/commands/import-programs.py
@@ -240,10 +240,9 @@ class Command(BaseCommand):
         # Remove any existing relationship to a current-version CIP
         # if it exists (in case the CIP changed in this import
         # for some reason).
-        existing_cips = program.cip
+        existing_cips = program.cip.filter(version=self.cip_version)
         if existing_cips.exists():
-            existing_cip = CIP.objects.get(version=self.cip_version, code=data['CIP'], program=program.pk)
-            program.cip.remove(existing_cip)
+            program.cip.remove(existing_cips)
 
         # Add an existing, current-version CIP object to the program.
         if data['CIP']:

--- a/programs/management/commands/import-programs.py
+++ b/programs/management/commands/import-programs.py
@@ -242,7 +242,7 @@ class Command(BaseCommand):
         # for some reason).
         existing_cips = program.cip.filter(version=self.cip_version)
         if existing_cips.exists():
-            program.cip.remove(existing_cips)
+            program.cip.remove(*existing_cips)
 
         # Add an existing, current-version CIP object to the program.
         if data['CIP']:


### PR DESCRIPTION
Fixed bug during the program import when we attempt to remove existing current-CIP relationships and pass in `code=data['CIP']` unnecessarily to the CIP queryset.