### PR TITLE
Basic front-end authentication for Archimedes

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url, include
 from django.urls import reverse_lazy
 from django.views.generic import TemplateView
+from django.contrib.auth.decorators import login_required
 
 from core.views import *
 
@@ -13,9 +14,9 @@ urlpatterns = [
         HomeView.as_view(),
         name='home'
     ),
-	url(
+    url(
         r'^search/$',
-        SearchView.as_view(template_name='search.html'),
+        login_required(SearchView.as_view(template_name='search.html')),
         name='search'
     ),
     url(

--- a/core/urls.py
+++ b/core/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
         name='home'
     ),
     url(
-        r'^search/$',
+        r'^manager/search/$',
         SearchView.as_view(template_name='search.html'),
         name='search'
     ),

--- a/core/urls.py
+++ b/core/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
     ),
     url(
         r'^search/$',
-        login_required(SearchView.as_view(template_name='search.html')),
+        SearchView.as_view(template_name='search.html'),
         name='search'
     ),
     url(

--- a/core/views.py
+++ b/core/views.py
@@ -5,6 +5,7 @@ from django.conf import settings
 
 from django.shortcuts import render
 from django.views.generic.base import TemplateView
+from django.contrib.auth.mixins import LoginRequiredMixin
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
@@ -29,7 +30,8 @@ class HomeView(TitleContextMixin, TemplateView):
     heading = 'UCF Search Service'
     local = settings.LOCAL
 
-class SearchView(TitleContextMixin, TemplateView):
+
+class SearchView(LoginRequiredMixin, TitleContextMixin, TemplateView):
     template_name = 'search.html'
     title = ''
     heading = 'UCF Search Service'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Django==1.11.23
 django-cors-headers==3.0.2
 django-filter==1.1.0
 django-mysql==2.5.0
+django-widget-tweaks==1.4.5
 djangorestframework==3.9.1
 docutils==0.15.2
 drf-dynamic-fields==0.3.0

--- a/settings.py
+++ b/settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     'drf_dynamic_fields',
     'django_mysql',
     'corsheaders',
+    'widget_tweaks',
 
     # Local
     'programs',
@@ -98,6 +99,10 @@ WSGI_APPLICATION = 'wsgi.application'
 SILENCED_SYSTEM_CHECKS = [
     'django_mysql.W002',
 ]
+
+LOGIN_REDIRECT_URL = 'home'
+
+LOGIN_URL = '/login/'
 
 try:
     from settings_local import *

--- a/settings.py
+++ b/settings.py
@@ -102,7 +102,7 @@ SILENCED_SYSTEM_CHECKS = [
 
 LOGIN_REDIRECT_URL = 'home'
 
-LOGIN_URL = '/login/'
+LOGIN_URL = '/manager/login/'
 
 try:
     from settings_local import *

--- a/settings_local.tmpl.py
+++ b/settings_local.tmpl.py
@@ -9,7 +9,7 @@ SECRET_KEY = 'SUPERSECRETKEYHEREPLEASEANDTHANKYOU'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-# Set to true for local development with the Angular
+# Set to true for local development with the Angular app
 LOCAL = False
 
 ALLOWED_HOSTS = []

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,7 +19,11 @@
           <img class="media-background object-fit-cover" src="{% static 'img/dark-lines.jpg' %}" alt="" data-object-fit="cover">
         </picture>
         <div class="container my-5">
-          <h1 class="display-4 text-inverse">{{ heading }}</h1>
+          {% block header_content %}
+          <h1 class="display-4 text-inverse">
+            {% block heading_text %}{{ heading }}{% endblock %}
+          </h1>
+          {% endblock %}
         </div>
       </div>
     </header>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+
+{% block heading_text %}
+<span class="d-block h6 font-weight-normal mb-3">UCF Search Service</span>
+Sign In
+{% endblock %}
+
+{% block body %}
+{% load widget_tweaks %}
+<div class="container my-5">
+  <div class="row">
+    <div class="col-lg-5">
+      <form class="form-horizontal" action="{% url 'login' %}" method="post">
+        {% for error in form.non_field_errors %}
+        <div class="alert alert-danger">{{error}}</div>
+        {% endfor %}
+
+        {% for field in form %}
+        <div class="form-group{% if field.errors %} has-danger{% endif %}">
+          {% if field %}
+            <label for="{{field.id_for_label}}" class="form-control-label">
+              {{field.label}}
+              {% if field.field.required %}<span class="text-danger">*<span class="sr-only"> Required field</span></span>{% endif %}
+            </label>
+            {{field|add_class:"form-control form-control-danger"|attr:"required"}}
+
+            {% if field.errors %}
+              {% for error in field.errors %}
+                <div class="form-control-feedback">{{error}}</div>
+              {% endfor %}
+            {% endif %}
+            <small class="form-text text-muted">{{field.help_text}}</small>
+          {% endif %}
+        </div>
+        {% endfor %}
+        <input type="hidden" name="next" value="{{next}}" />
+        {% csrf_token %}
+        <div class="form-group mt-4">
+          <button type="submit" class="btn btn-primary">Sign in</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/logout.html
+++ b/templates/logout.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+
+{% block heading_text %}
+<span class="d-block h6 font-weight-normal mb-3">UCF Search Service</span>
+Sign Out
+{% endblock %}
+
+{% block body %}
+<div class="container my-5">
+  You have been successfully signed out.  <a href="{% url 'home' %}">Return to home page</a>
+</div>
+{% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,5 +1,21 @@
 {% extends 'base.html' %}
+
 {% load static %}
+
+{% block header_content %}
+<div class="row">
+  <div class="col">
+    <h1 class="display-4 text-inverse">
+      <span class="d-block h6 font-weight-normal mb-3">UCF Search Service</span>
+      Archimedes
+    </h1>
+  </div>
+  <div class="col-auto">
+    <a href="{% url 'logout' %}" class="btn btn-outline-inverse">Sign Out</a>
+  </div>
+</div>
+{% endblock %}
+
 {% block body %}
 
 <app-root></app-root>

--- a/urls.py
+++ b/urls.py
@@ -40,11 +40,11 @@ urlpatterns = [
         name='favicon'
         ),
     url(
-        r'^login/$',
+        r'^manager/login/$',
         LoginView.as_view(template_name='login.html'), name='login'
     ),
     url(
-        r'^logout/$',
+        r'^manager/logout/$',
         LogoutView.as_view(template_name='logout.html'), name='logout'
     ),
     url(r'^',

--- a/urls.py
+++ b/urls.py
@@ -40,6 +40,10 @@ urlpatterns = [
         name='favicon'
         ),
     url(
+        r'^manager/$',
+        RedirectView.as_view(pattern_name='login'), name='manager'
+    ),
+    url(
         r'^manager/login/$',
         LoginView.as_view(template_name='login.html'), name='login'
     ),
@@ -49,5 +53,5 @@ urlpatterns = [
     ),
     url(r'^',
         include('core.urls')
-        )
+    )
 ]

--- a/urls.py
+++ b/urls.py
@@ -15,6 +15,7 @@ Including another URLconf
 """
 from django.conf.urls import url, include
 from django.contrib import admin
+from django.contrib.auth.views import LoginView, LogoutView
 from django.views.generic import RedirectView
 
 urlpatterns = [
@@ -38,6 +39,14 @@ urlpatterns = [
         RedirectView.as_view(url='/static/favicon.ico'),
         name='favicon'
         ),
+    url(
+        r'^login/$',
+        LoginView.as_view(template_name='login.html'), name='login'
+    ),
+    url(
+        r'^logout/$',
+        LogoutView.as_view(template_name='logout.html'), name='logout'
+    ),
     url(r'^',
         include('core.urls')
         )


### PR DESCRIPTION
Places basic local Django authentication in front of Archimedes.

As part of this update, Archimedes has been moved from /search/ to /manager/search/ as a quick workaround for Varnish issues.  If having the URL at /search/ is critical for distribution to alpha testers, we can look into working with Tim's team to update the vcl to accommodate, but for now, this is our quickest option to get the repo to a tag-able state.