### PR TITLE
Teledata - Map compatibility updates

### DIFF
--- a/teledata/filters.py
+++ b/teledata/filters.py
@@ -1,7 +1,15 @@
 import django_filters
 from django_filters import rest_framework as filters
 
-from teledata.models import CombinedTeledata
+from teledata.models import Department, CombinedTeledata
+
+
+class DepartmentFilter(django_filters.FilterSet):
+    class Meta:
+        model = Department
+        fields = (
+            'org__import_id',
+        )
 
 
 class CombinedTeledataFilter(django_filters.FilterSet):

--- a/teledata/serializers.py
+++ b/teledata/serializers.py
@@ -4,6 +4,7 @@ import warnings
 
 from django.db import IntegrityError
 
+
 class BuildingSerializer(serializers.ModelSerializer):
     class Meta:
         fields = '__all__'
@@ -13,11 +14,13 @@ class BuildingSerializer(serializers.ModelSerializer):
 class OrganizationBriefSerializer(serializers.ModelSerializer):
     class Meta:
         fields = (
+            'id',
             'name',
             'phone',
             'fax',
             'url',
-            'room'
+            'room',
+            'import_id'
         )
         model = Organization
 

--- a/teledata/views.py
+++ b/teledata/views.py
@@ -15,15 +15,21 @@ from teledata.pagination import BackwardsCompatiblePagination
 
 from rest_framework.filters import OrderingFilter
 
+
 # Create your views here.
+
 class BuildingListView(generics.ListAPIView):
     queryset = Building.objects.all()
     serializer_class = BuildingSerializer
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ['id', 'name']
 
 
 class DepartmentListView(generics.ListAPIView):
     queryset = Department.objects.all()
     serializer_class = DepartmentSerializer
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ['id', 'name']
 
 
 class DepartmentDetailView(generics.RetrieveAPIView):
@@ -35,21 +41,25 @@ class DepartmentDetailView(generics.RetrieveAPIView):
 class OrganizationListView(generics.ListAPIView):
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ['id', 'name']
 
 
 class StaffListView(generics.ListAPIView):
     queryset = Staff.objects.all()
     serializer_class = StaffSerializer
 
+
 class CombinedTeledataListView(generics.ListAPIView):
     queryset = CombinedTeledata.objects.all()
     serializer_class = CombinedTeledataSerializer
 
+
 class CombinedTeledataSearchView(CombinedTeledataListView):
     filter_class = CombinedTeledataFilter
-    filter_backends = [DjangoFilterBackend,OrderingFilter]
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
     pagination_class = BackwardsCompatiblePagination
-    ordering_fields = ['id', 'score']
+    ordering_fields = ['id', 'score', 'sort_name']
 
     def get_queryset(self):
         if self.request.GET.get('search') is not None:

--- a/teledata/views.py
+++ b/teledata/views.py
@@ -26,6 +26,7 @@ class BuildingListView(generics.ListAPIView):
 
 
 class DepartmentListView(generics.ListAPIView):
+    filter_class = DepartmentFilter
     queryset = Department.objects.all()
     serializer_class = DepartmentSerializer
     filter_backends = [DjangoFilterBackend, OrderingFilter]

--- a/templates/home.html
+++ b/templates/home.html
@@ -108,6 +108,40 @@
               </tr>
               <tr>
                 <td>
+                  <code>ordering</code>
+                </td>
+                <td>Modifies how results are ordered. (By default, results are ordered by <code>score</code> descending.)</td>
+                <td>
+                  <ul>
+                    <li>
+                      <div><code>id</code></div>
+                      <p class="small">Sort by record ID, ascending</p>
+                    </li>
+                    <li>
+                      <div><code>-id</code></div>
+                      <p class="small">Sort by record ID, descending</p>
+                    </li>
+                    <li>
+                      <div><code>score</code></div>
+                      <p class="small">Sort by relevance score, ascending</p>
+                    </li>
+                    <li>
+                      <div><code>-score</code></div>
+                      <p class="small">Sort by relevance score, descending</p>
+                    </li>
+                    <li>
+                      <div><code>sort_name</code></div>
+                      <p class="small">Sort by the record's sort-friendly name, ascending</p>
+                    </li>
+                    <li>
+                      <div><code>-sort_name</code></div>
+                      <p class="small">Sort by the record's sort-friendly name, descending</p>
+                    </li>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <td>
                   <code>limit</code>
                 </td>
                 <td>The maximum number of records to return.</td>
@@ -386,6 +420,32 @@
                 <td>The starting position of the query in relation to the complete set of results.</td>
                 <td>Number</td>
               </tr>
+              <tr>
+                <td>
+                  <code>ordering</code>
+                </td>
+                <td>Modifies how results are ordered. (By default, results are ordered by <code>id</code> descending.)</td>
+                <td>
+                  <ul>
+                    <li>
+                      <div><code>id</code></div>
+                      <p class="small">Sort by record ID, ascending</p>
+                    </li>
+                    <li>
+                      <div><code>-id</code></div>
+                      <p class="small">Sort by record ID, descending</p>
+                    </li>
+                    <li>
+                      <div><code>name</code></div>
+                      <p class="small">Sort by the record's name, ascending</p>
+                    </li>
+                    <li>
+                      <div><code>-name</code></div>
+                      <p class="small">Sort by the record's name, descending</p>
+                    </li>
+                  </ul>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -514,6 +574,32 @@
                 </td>
                 <td>The starting position of the query in relation to the complete set of results.</td>
                 <td>Number</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>ordering</code>
+                </td>
+                <td>Modifies how results are ordered. (By default, results are ordered by <code>id</code> descending.)</td>
+                <td>
+                  <ul>
+                    <li>
+                      <div><code>id</code></div>
+                      <p class="small">Sort by record ID, ascending</p>
+                    </li>
+                    <li>
+                      <div><code>-id</code></div>
+                      <p class="small">Sort by record ID, descending</p>
+                    </li>
+                    <li>
+                      <div><code>name</code></div>
+                      <p class="small">Sort by the record's name, ascending</p>
+                    </li>
+                    <li>
+                      <div><code>-name</code></div>
+                      <p class="small">Sort by the record's name, descending</p>
+                    </li>
+                  </ul>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -691,6 +777,32 @@
                 </td>
                 <td>The starting position of the query in relation to the complete set of results.</td>
                 <td>Number</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>ordering</code>
+                </td>
+                <td>Modifies how results are ordered. (By default, results are ordered by <code>id</code> descending.)</td>
+                <td>
+                  <ul>
+                    <li>
+                      <div><code>id</code></div>
+                      <p class="small">Sort by record ID, ascending</p>
+                    </li>
+                    <li>
+                      <div><code>-id</code></div>
+                      <p class="small">Sort by record ID, descending</p>
+                    </li>
+                    <li>
+                      <div><code>name</code></div>
+                      <p class="small">Sort by the record's name, ascending</p>
+                    </li>
+                    <li>
+                      <div><code>-name</code></div>
+                      <p class="small">Sort by the record's name, descending</p>
+                    </li>
+                  </ul>
+                </td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Updates that facilitate support for Map shifting to using the Django Search Service for retrieving teledata instead of the old PHP search service.

- Added ability to order organizations, departments, and buildings views by name (as well as ID).  The combined teledata view is also sortable by `sort_name` now.
- Added `id` and `import_id` to `OrganizationBriefSerializer`, since Map depends on the `import_id` value being available on nested orgs in the departments list view.  `id` is added for clarity/to differentiate between the two values and for consistency with the `BuildingSerializer`.
- Added ability to filter the departments list by org `import_id`.