### PR TITLE
Teledata search option updates/fixes

### DIFF
--- a/teledata/pagination.py
+++ b/teledata/pagination.py
@@ -1,13 +1,14 @@
-from rest_framework.pagination import PageNumberPagination
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 from collections import OrderedDict
 
-class BackwardsCompatiblePagination(PageNumberPagination):
+
+class BackwardsCompatiblePagination(LimitOffsetPagination):
     def get_paginated_response(self, data):
         fields = OrderedDict()
-        fields['count'] = self.page.paginator.count
+        fields['count'] = self.count
         # Added for backwards compatibility
-        fields['resultCount'] = self.page.paginator.count
+        fields['resultCount'] = self.count
         fields['next'] = self.get_next_link()
         fields['previous'] = self.get_previous_link()
         fields['results'] = data

--- a/teledata/views.py
+++ b/teledata/views.py
@@ -63,8 +63,9 @@ class CombinedTeledataSearchView(CombinedTeledataListView):
     ordering_fields = ['id', 'score', 'sort_name']
 
     def get_queryset(self):
-        if self.request.GET.get('search') is not None:
-            return CombinedTeledata.objects.search(self.request.GET.get('search')).order_by('-score')
+        search_query = self.request.GET.get('search')
+        if search_query:
+            return CombinedTeledata.objects.search(search_query).order_by('-score')
         else:
             # There is no score because the query isn't run. Order by id
             return CombinedTeledata.objects.none().order_by('id')


### PR DESCRIPTION
- Updated `CombinedTeledataSearchView` to _not_ fetch search results if the `search` param is present, but empty, for consistency with the old search service
- Updated `BackwardsCompatiblePagination` class to extend from `LimitOffsetPagination` to add `limit` query param support to the combined teledata search.

