### PR TITLE
Hotfixes (typo; invalid program logic adjustments)

### DIFF
--- a/programs/management/commands/import-programs.py
+++ b/programs/management/commands/import-programs.py
@@ -126,6 +126,11 @@ class Command(BaseCommand):
         if data['Meta Data'][0]['Degree'] in ['PND', 'PRP']:
             return False
 
+        # Is this program an undergraduate program
+        # offered at at least one location?
+        if self.career_mappings[data['Career']] == 'Undergraduate' and len(data['Active Locations']) == 0:
+            return False
+
         # Ensure other required values are not empty
         required = [
             data['College_Full'],
@@ -147,6 +152,11 @@ class Command(BaseCommand):
         Returns whether or not APIM data representing a
         subplan is considered valid.
         """
+        # Is this program an undergraduate program
+        # offered at at least one location?
+        if self.career_mappings[data['Career']] == 'Undergraduate' and len(data['Active Locations']) == 0:
+            return False
+
         # Ensure other required values are not empty
         required = [
             data['Subplan'],

--- a/programs/management/commands/import-programs.py
+++ b/programs/management/commands/import-programs.py
@@ -126,10 +126,6 @@ class Command(BaseCommand):
         if data['Meta Data'][0]['Degree'] in ['PND', 'PRP']:
             return False
 
-        # Is this program offered at at least one location?
-        if len(data['Active Locations']) == 0:
-            return False
-
         # Ensure other required values are not empty
         required = [
             data['College_Full'],
@@ -151,10 +147,6 @@ class Command(BaseCommand):
         Returns whether or not APIM data representing a
         subplan is considered valid.
         """
-        # Is this program offered at at least one location?
-        if len(data['Active Locations']) == 0:
-            return False
-
         # Ensure other required values are not empty
         required = [
             data['Subplan'],

--- a/programs/management/commands/import-programs.py
+++ b/programs/management/commands/import-programs.py
@@ -498,7 +498,7 @@ Import Complete!
             self.stdout.write(
                 (
                     '{0} programs previously marked as invalid were made '
-                    'valid during this import:',
+                    'valid during this import:'
                 ).format(self.programs_revalidated),
                 ending='\n\n'
             )

--- a/programs/management/commands/import-programs.py
+++ b/programs/management/commands/import-programs.py
@@ -105,7 +105,7 @@ class Command(BaseCommand):
 
                 if len(d['SubPlans']) > 0:
                     for sp in d['SubPlans']:
-                        if self.subplan_is_valid(sp):
+                        if self.subplan_is_valid(sp, d):
                             self.add_subplan(sp, program)
                         else:
                             self.programs_skipped += 1
@@ -147,14 +147,14 @@ class Command(BaseCommand):
 
         return True
 
-    def subplan_is_valid(self, data):
+    def subplan_is_valid(self, data, parent_data):
         """
         Returns whether or not APIM data representing a
         subplan is considered valid.
         """
         # Is this program an undergraduate program
         # offered at at least one location?
-        if self.career_mappings[data['Career']] == 'Undergraduate' and len(data['Active Locations']) == 0:
+        if self.career_mappings[parent_data['Career']] == 'Undergraduate' and len(data['Active Locations']) == 0:
             return False
 
         # Ensure other required values are not empty

--- a/programs/management/commands/import-programs.py
+++ b/programs/management/commands/import-programs.py
@@ -127,8 +127,12 @@ class Command(BaseCommand):
             return False
 
         # Is this program an undergraduate program
-        # offered at at least one location?
-        if self.career_mappings[data['Career']] == 'Undergraduate' and len(data['Active Locations']) == 0:
+        # (not a minor or certificate) offered at at least one location?
+        if (
+            self.career_mappings[data['Career']] == 'Undergraduate'
+            and data['Meta Data'][0]['Degree'] not in ['CER', 'CRT', 'MIN']
+            and len(data['Active Locations']) == 0
+        ):
             return False
 
         # Ensure other required values are not empty
@@ -152,7 +156,7 @@ class Command(BaseCommand):
         Returns whether or not APIM data representing a
         subplan is considered valid.
         """
-        # Is this program an undergraduate program
+        # Is this program an undergraduate subplan
         # offered at at least one location?
         if self.career_mappings[parent_data['Career']] == 'Undergraduate' and len(data['Active Locations']) == 0:
             return False


### PR DESCRIPTION
- Removed an errant comma in the program import's `print_results()`.
- Updated program is_valid logic to ensure we only check active locations against undergraduate programs that are not minors or certificates.