### PR TITLE
Tandemvault import - added exception handling when multiple images with source ID are found

### DIFF
--- a/images/management/commands/import-tandemvault-images.py
+++ b/images/management/commands/import-tandemvault-images.py
@@ -692,6 +692,16 @@ class Command(BaseCommand):
                         .format(tandemvault_image['id'])
                     )
                     return None
+        except Image.MultipleObjectsReturned:
+            self.images_skipped += 1
+            logging.warning(
+                (
+                    'Multiple results for image with ID {0} found! '
+                    'Skipping this image.'
+                )
+                .format(tandemvault_image['id'])
+            )
+            return None
         except Image.DoesNotExist:
             process_tags = True
 


### PR DESCRIPTION
This scenario shouldn't be happening, but in cases where it does happen anyway, I've added an exception to just skip the result instead of erroring out.