### PR TITLE
A few more Tandemvault tag + image import fixes

### DIFF
--- a/images/management/commands/import-tandemvault-images.py
+++ b/images/management/commands/import-tandemvault-images.py
@@ -277,7 +277,7 @@ class Rekognition(object):
         """
         data = {
             'labels': [],
-            'mean_confidence_score': None
+            'labels_mean_confidence_score': None
         }
 
         if image_file is not None:

--- a/images/management/commands/import-tandemvault-images.py
+++ b/images/management/commands/import-tandemvault-images.py
@@ -427,7 +427,7 @@ class ImageData(object):
             uploadset_tag_name_lower = self.uploadset_json['title'].lower().strip()
             if uploadset_tag_name_lower not in self.unique_tag_names:
                 self.unique_tag_names.add(uploadset_tag_name_lower)
-                self.tv_tags.append(uploadset_tag_name)
+                self.tv_tags.append(uploadset_tag_name_lower)
 
         # Generate and assign tags from Rekognition:
         if rk and self.generate_tags:

--- a/images/management/commands/import-tandemvault-tags.py
+++ b/images/management/commands/import-tandemvault-tags.py
@@ -149,7 +149,7 @@ class Command(BaseCommand):
     '''
     def clean_tag_name(self, name):
         try:
-            name = name.decode('utf-8')
+            name = name.encode('utf-8').decode('utf-8')
         except (UnicodeDecodeError, UnicodeEncodeError):
             # we tried; make it behave
             name = unidecode(name)


### PR DESCRIPTION
Fixed a few outlying bugs in the updated tandemvault image and tag importers (incorrect variable/key names; string encoding differences between Python 2/3.)