### PR TITLE
Catalog description imports by program ID

### DIFF
--- a/settings_local.tmpl.py
+++ b/settings_local.tmpl.py
@@ -252,3 +252,18 @@ GRADUATE_SLATE_ENDPOINTS = {
         'password': ''
     }
 }
+
+# The base URL to use when building catalog URLs during the catalog import
+CATALOG_URL_BASE = 'https://catalog.ucf.edu'
+
+# The base URL of the Acalog API
+CATALOG_API_BASE = ''
+
+# The API key used to connect to Acalog
+CATALOG_API_KEY = ''
+
+# The ID of the current active undergraduate catalog in Acalog
+CATALOG_UNDERGRADUATE_ID = 18
+
+# The ID of the current active graduate catalog in Acalog
+CATALOG_GRADUATE_ID = 17


### PR DESCRIPTION
- Updated the catalog import to accept a new `--program-ids` arg, which accepts a list of program pk's that should be processed (instead of processing all undergrad or all grad programs)
- Added new catalog-related settings to settings_local.py that are necessary for by-program catalog imports to work, and allow us to reduce the number of required params to pass to the import command.