### PR TITLE
Catalog import - list processing improvements

### DIFF
--- a/programs/management/commands/import-catalog-data.py
+++ b/programs/management/commands/import-catalog-data.py
@@ -431,7 +431,7 @@ class Command(BaseCommand):
             'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
             'p', 'br', 'pre', 'sup', 'sub',
             'table', 'tbody', 'thead', 'tr', 'td',
-            'ul', 'li', 'ol',
+            'ul', 'li', 'ol', 'dl', 'dt', 'dd',
             'b', 'em', 'i', 'strong', 'u'
         ]
         if not strip_links:

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -153,18 +153,26 @@ class ContentNode(object):
     def __list_processing(self):
         """
         Processes nodes determined to be LISTs. We currently
-        don't send these off to comprehend for processing and
+        don't send these off to Comprehend for processing and
         instead do some regex lookups to determine if they
-        contain progam course information.
+        contain program course information.
         """
         course_re = re.compile(r'([A-Za-z]{3,4}\s)([0-9]{4})')
-
-        parsed_lines = self.html_node.find_all(['li', 'dt', 'dd'], recursive=False)
         course_line_score = 0
+
+        parsed_lines = []
+        if self.node_type == ContentNodeType.LIST:
+            # If this is actually a list already, extract text
+            # from each child list item
+            parsed_lines = [li.text for li in self.html_node.find_all(['li', 'dt', 'dd'], recursive=False)]
+        else:
+            # If this is something else (e.g. a paragraph),
+            # just use self.cleaned
+            parsed_lines = self.cleaned.splitlines()
 
         if parsed_lines:
             for li in parsed_lines:
-                result = course_re.match(li.text)
+                result = course_re.match(li)
                 if result:
                     course_line_score += 100
 
@@ -249,6 +257,7 @@ class ContentNode(object):
         new_content = "<ul><li>{0}</li></ul>".format(inner_html)
         new_soup = BeautifulSoup(new_content, 'html.parser')
         self.html_node = new_soup
+        self.tag = 'ul'
 
     #endregion
 

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -162,12 +162,15 @@ class ContentNode(object):
         parsed_lines = self.html_node.find_all('li', recursive=False)
         course_line_score = 0
 
-        for li in parsed_lines:
-            result = course_re.match(li.text)
-            if result:
-                course_line_score += 100
+        if parsed_lines:
+            for li in parsed_lines:
+                result = course_re.match(li.text)
+                if result:
+                    course_line_score += 100
 
-        avg_score = course_line_score / len(parsed_lines)
+            avg_score = course_line_score / len(parsed_lines)
+        else:
+            avg_score = 0
 
         if avg_score > 80:
             self.content_category = ContentCategory.COURSES

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -159,7 +159,7 @@ class ContentNode(object):
         """
         course_re = re.compile(r'([A-Za-z]{3,4}\s)([0-9]{4})')
 
-        parsed_lines = self.html_node.find_all('li', recursive=False)
+        parsed_lines = self.html_node.find_all(['li', 'dt', 'dd'], recursive=False)
         course_line_score = 0
 
         if parsed_lines:

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -159,15 +159,15 @@ class ContentNode(object):
         """
         course_re = re.compile(r'([A-Za-z]{3,4}\s)([0-9]{4})')
 
-        cleaned_lines = self.cleaned.splitlines()
+        parsed_lines = self.html_node.find_all('li', recursive=False)
         course_line_score = 0
 
-        for line in cleaned_lines:
-            result = course_re.match(line)
+        for li in parsed_lines:
+            result = course_re.match(li.text)
             if result:
                 course_line_score += 100
 
-        avg_score = course_line_score / len(cleaned_lines)
+        avg_score = course_line_score / len(parsed_lines)
 
         if avg_score > 80:
             self.content_category = ContentCategory.COURSES


### PR DESCRIPTION
- Modified how `__list_processing()` performs regex matching against list items so that complete `<li>`s are processed as individual lines, instead of using `self.cleaned.splitlines()` which can split lists in unexpected ways depending on inner elements and newline usage.
- Updated the importer to allow `dl`, `dt` and `dd` elements.