### PR TITLE
Catalog import - contact info extraction improvements

### DIFF
--- a/programs/management/commands/import-catalog-data.py
+++ b/programs/management/commands/import-catalog-data.py
@@ -281,6 +281,13 @@ class Command(BaseCommand):
             programs = programs.filter(career__name=career_name)
 
         for p in programs:
+            # Is this a graduate program?
+            # (Necessary when running import by program IDs)
+            if self.program_ids:
+                is_graduate = p.career.name == 'Graduate'
+            else:
+                is_graduate = self.graduate
+
             # Wipe out existing catalog URL
             p.catalog_url = None
             p.save()
@@ -317,7 +324,8 @@ class Command(BaseCommand):
                     description_type=description_type,
                     description=self.get_description(
                         matched_entry.id,
-                        matched_entry.catalog_id
+                        matched_entry.catalog_id,
+                        is_graduate
                     ),
                     program=p.program
                 )
@@ -345,7 +353,7 @@ class Command(BaseCommand):
         print('Matched {0}/{1} of Fetched Catalog Entries to at Least One Existing Program: {2:.0f}%'.format(len([x for x in self.catalog_programs if x.has_matches == True]), len(self.catalog_programs), len([x for x in self.catalog_programs if x.has_matches == True]) / float(len(self.catalog_programs)) * 100))
 
 
-    def get_description(self, program_id, catalog_id):
+    def get_description(self, program_id, catalog_id, is_graduate):
         url = '{0}content?key={1}&format=xml&method=getItems&type=programs&ids[]={2}&catalog={3}'.format(
             self.path,
             self.key,
@@ -364,7 +372,7 @@ class Command(BaseCommand):
         # Strip xmlns attributes to parse string to xml without namespaces
         data = re.sub(b' xmlns(?:\:[a-z]*)?="[^"]+"', b'', raw_data)
         root = BeautifulSoup(data, 'xml')
-        if self.graduate:
+        if is_graduate:
             cores = root.find('cores')
             description_xml = cores.find('core').encode_contents()
         else:
@@ -477,12 +485,15 @@ class Command(BaseCommand):
         for span_match in description_html.find_all('span'):
             span_match.unwrap()
 
-        # Un-soup(?) the soup; strip newlines:
-        nl_regex = re.compile(r'[\r\n\t]')
-        description_html = nl_regex.sub(' ', str(description_html))
+        # Un-soup(?) the soup
+        description_html = str(description_html)
 
-        # Fix garbage characters due to mismatched encodings
+        # Strip newlines:
+        description_html = re.sub(r'[\r\n\t]', ' ', description_html)
+
+        # Fix various garbage characters
         description_html = unicodedata.normalize('NFKC', description_html)
+        description_html = description_html.replace('\u200b', '')
 
         # Other miscellaneous string replacements:
         description_html = re.sub(r'^(Program|Track) Description<p>', '<p>', description_html)

--- a/programs/management/commands/import-catalog-data.py
+++ b/programs/management/commands/import-catalog-data.py
@@ -12,6 +12,7 @@ from operator import attrgetter
 import xml.etree.ElementTree as ET
 from fuzzywuzzy import fuzz
 from bs4 import BeautifulSoup, NavigableString
+import unicodedata
 
 
 def clean_name(program_name):
@@ -480,8 +481,8 @@ class Command(BaseCommand):
         nl_regex = re.compile(r'[\r\n\t]')
         description_html = nl_regex.sub(' ', str(description_html))
 
-        # Strip characters outside the ASCII range:
-        description_html = re.sub(r'[\x01-\x1F\x7F]', '', description_html)
+        # Fix garbage characters due to mismatched encodings
+        description_html = unicodedata.normalize('NFKC', description_html)
 
         # Other miscellaneous string replacements:
         description_html = re.sub(r'^(Program|Track) Description<p>', '<p>', description_html)

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -267,7 +267,8 @@ class ContentNode(object):
         retval = False
 
         # Is this line a phone number?
-        # TODO do we need to account for other written phone variants? e.g. (407) 823-...
+        # NOTE: This check currently only tests against the basic
+        # format 555-555-5555 (parentheses/spaces aren't accounted for)
         phone_re = re.compile(r'^\d{3}\-\d{3}\-\d{4}$')
         phone_result = phone_re.fullmatch(line)
 
@@ -284,8 +285,6 @@ class ContentNode(object):
             or (bldgs and line in bldgs.values())
         ):
             retval = True
-
-        # TODO add more complex regex lookups?
 
         return retval
 

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -27,7 +27,6 @@ class ContentCategory(Enum):
 
 college_names = College.objects.values_list('full_name', flat=True)
 dept_names = Department.objects.values_list('name', flat=True)
-bldgs = Building.objects.values('name', 'abbr')
 
 class ContentNode(object):
     """
@@ -261,7 +260,7 @@ class ContentNode(object):
 
     def __line_is_common_contact_info(self, line):
         """
-        Catches exact or near-exact matches for common types of
+        Catches exact matches for common types of
         contact info that reside on their own lines of text.
         """
         retval = False
@@ -282,7 +281,6 @@ class ContentNode(object):
             or email_result
             or (college_names and line in college_names)
             or (dept_names and line in dept_names)
-            or (bldgs and line in bldgs.values())
         ):
             retval = True
 

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -25,8 +25,8 @@ class ContentCategory(Enum):
 
 #endregion
 
-college_names = College.objects.values_list('full_name', flat=True)
-dept_names = Department.objects.values_list('name', flat=True)
+college_names = [x.lower() for x in College.objects.values_list('full_name', flat=True)]
+dept_names = [x.lower() for x in Department.objects.values_list('name', flat=True)]
 
 class ContentNode(object):
     """
@@ -279,8 +279,8 @@ class ContentNode(object):
         if (
             phone_result
             or email_result
-            or (college_names and line in college_names)
-            or (dept_names and line in dept_names)
+            or (college_names and line.lower() in college_names)
+            or (dept_names and line.lower() in dept_names)
         ):
             retval = True
 


### PR DESCRIPTION
- Made updates to the importer's `sanitize_description()` to better handle characters in descriptions we don't want.  Ensuring we strip garbage characters appropriately helps improve contact info matching and scoring.
- Updated the `ContentNode` class to store cleaned node text in two separate fields--one that stores all text content in a single string (`self.cleaned_str`), and another that stores them in a list per-line (`self.cleaned_lines`).  Doing this avoids the need to repeatedly split the cleaned markup in various functions, and using `soup.stripped_strings` instead of `soup.get_text(separator='\n').strip()` should be more accurate and trims each line + eliminates empty string nodes.
- Added basic string and regex matching for individual ContentNode lines to detect common types of contact info that consume their entire line (`ContentNode.__line_is_common_contact_info()`).  Doing this helps catch things like emails, phone numbers, college and (some) department names early instead of passing them along to Comprehend.
- Fixed a bug where short catalog descriptions wouldn't import properly when the import command is passed a list of program IDs (instead of importing by career type)