### PR TITLE
Catalog import - extraneous updates from single-description-fetch

### DIFF
--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -157,7 +157,7 @@ class ContentNode(object):
         instead do some regex lookups to determine if they
         contain program course information.
         """
-        course_re = re.compile(r'([A-Za-z]{3,4}\s)([0-9]{4})')
+        course_re = re.compile(r'([A-Za-z]{3,4}\s)([0-9]{4})([A-Za-z]{1})?')
         course_line_score = 0
 
         parsed_lines = []


### PR DESCRIPTION
Ported over some updates present in the `single-description-fetch` I want to make sure are included with these importer updates, regardless of whether or not I'm able to finish that feature:

- Updated the course matching regex in `ContentNode.__list_processing()`
- Added node initializer to Oscar