### PR TITLE
Catalog import - heading order

### DIFF
--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -10,7 +10,7 @@ import re
 #region Helper Enums
 
 class ContentNodeType(Enum):
-    TITLE = 'title'
+    HEADING = 'heading'
     LIST = 'list'
     LIST_ITEM = 'list item'
     TABLE = 'table'
@@ -44,7 +44,7 @@ class ContentNode(object):
         'ORGANIZATION'
     ]
 
-    TITLE_TAGS = [
+    HEADING_TAGS = [
         'h1',
         'h2',
         'h3',
@@ -65,8 +65,8 @@ class ContentNode(object):
         if self.tag == None:
             return None
 
-        if self.tag in self.TITLE_TAGS:
-            return ContentNodeType.TITLE
+        if self.tag in self.HEADING_TAGS:
+            return ContentNodeType.HEADING
         if self.tag in ['ul', 'ol', 'dl']:
             return ContentNodeType.LIST
         elif self.tag in ['li']:
@@ -117,7 +117,7 @@ class ContentNode(object):
 
         self.__set_node_details()
 
-        # Set subtitle, sibling elems (if this is a TITLE node)
+        # Set subheading, sibling elems (if this is a HEADING node)
         self.subheadings = self.__get_subheadings()
         self.next_sibling_headings = self.__get_next_sibling_headings()
 
@@ -137,8 +137,8 @@ class ContentNode(object):
         dealing with, further type specific processing
         will happen.
         """
-        if self.node_type == ContentNodeType.TITLE:
-            self.__title_processing()
+        if self.node_type == ContentNodeType.HEADING:
+            self.__heading_processing()
         elif self.node_type == ContentNodeType.LIST:
             self.__list_processing()
         elif self.node_type == ContentNodeType.LIST_ITEM:
@@ -148,9 +148,9 @@ class ContentNode(object):
         else:
             return
 
-    def __title_processing(self):
+    def __heading_processing(self):
         """
-        Processes nodes determined to be TITLEs. We currently
+        Processes nodes determined to be HEADINGs. We currently
         don't send these off to comprehend for processing and
         instead do simple string lookups.
         """
@@ -286,9 +286,9 @@ class ContentNode(object):
     def __get_subheadings(self):
         """
         Returns immediate subheadings of the given node (non-recursive).
-        Returns False if the given node is not the TITLE type.
+        Returns False if the given node is not the HEADING type.
         """
-        if self.node_type != ContentNodeType.TITLE:
+        if self.node_type != ContentNodeType.HEADING:
             return False
 
         if self.tag == 'h6':
@@ -298,31 +298,31 @@ class ContentNode(object):
         # Increment through all possible immediate subheadings
         # for this node.
         # Accounts for skipped heading order (malformed markup.)
-        subtitles = []
-        possible_subtitle_tags = self.TITLE_TAGS[self.TITLE_TAGS.index(self.tag) + 1:]
+        subheadings = []
+        possible_subheading_tags = self.HEADING_TAGS[self.HEADING_TAGS.index(self.tag) + 1:]
 
-        for subtitle_tag in possible_subtitle_tags:
-            if subtitles:
+        for subheading_tag in possible_subheading_tags:
+            if subheadings:
                 break
             # Traverse the DOM for this type of subheading until
             # the next equivalent heading is found.
             # (e.g. if self.tag == 'h2', search for all adjacent h3s
             # until an adjacent h2 is found)
-            for sibling in self.html_node.find_next_siblings([self.tag, subtitle_tag]):
+            for sibling in self.html_node.find_next_siblings([self.tag, subheading_tag]):
                 if sibling.name == self.tag:
                     break
-                elif sibling.name == subtitle_tag:
-                    subtitles.append(sibling)
+                elif sibling.name == subheading_tag:
+                    subheadings.append(sibling)
 
-        return subtitles
+        return subheadings
 
     def __get_next_sibling_headings(self):
         """
         Returns immediate sibling headings of the given node.
         Does not include previous siblings.
-        Returns False if the given node is not the TITLE type.
+        Returns False if the given node is not the HEADING type.
         """
-        if self.node_type != ContentNodeType.TITLE:
+        if self.node_type != ContentNodeType.HEADING:
             return False
 
         # Increment through all possible immediate subheadings
@@ -409,7 +409,7 @@ class ContentNode(object):
 
     #region Public Functions
 
-    def increment_title_tag(self, previous_heading_tag):
+    def increment_heading_tag(self, previous_heading_tag):
         """
         Increments or decrements a heading tag based on the
         `previous_heading` node passed in.

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -325,9 +325,6 @@ class ContentNode(object):
         if self.node_type != ContentNodeType.HEADING:
             return False
 
-        # Increment through all possible immediate subheadings
-        # for this node.
-        # Accounts for skipped heading order (malformed markup.)
         siblings = []
         parent_tag = 'h{0}'.format(int(self.tag[1:2]) - 1)
 

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -94,6 +94,7 @@ class Oscar:
             if node.content_category in self.SKIP:
                 continue
 
+<<<<<<< HEAD
             # If this is a title, see if it's the right heading level
             if node.node_type == ContentNodeType.TITLE and previous_node:
                 if previous_heading == None:
@@ -105,6 +106,29 @@ class Oscar:
                         node.increment_title_tag(previous_heading)
                         setval.append(node)
                         previous_heading = node
+=======
+            # If this is a title, make sure headings are ordered correctly:
+            if node.node_type == ContentNodeType.TITLE:
+                if node.tag == 'h1':
+                    # Don't allow h1's:
+                    node.change_tag('h2')
+                elif previous_heading and node.html_node in previous_heading.subheadings:
+                    # Enforce correct ordering of immediate subheadings:
+                    node.increment_title_tag(previous_heading)
+
+                retval.append(node)
+                previous_heading = node
+                previous_node = node
+                continue
+
+            # If the previous and next node are skippable,
+            # then skip this one too.
+            if (previous_node
+                and len(nodes) > idx + 1
+                and previous_node.content_category in skip
+                and nodes[idx + 1].content_category in skip):
+                continue
+>>>>>>> 28b8fe6... WIP updating how heading incrementing works
 
             # By default, just add the node
             setval.append(node)

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -113,15 +113,10 @@ class Oscar:
                 if node.tag == 'h1':
                     node.change_tag('h2')
                 # Enforce correct ordering of immediate subheadings:
-                # TODO there is probably a cleaner way of doing this
-                elif previous_headings['h2'] and node.html_node in previous_headings['h2'].subheadings:
-                    node.increment_title_tag(previous_headings['h2'])
-                elif previous_headings['h3'] and node.html_node in previous_headings['h3'].subheadings:
-                    node.increment_title_tag(previous_headings['h3'])
-                elif previous_headings['h4'] and node.html_node in previous_headings['h4'].subheadings:
-                    node.increment_title_tag(previous_headings['h4'])
-                elif previous_headings['h5'] and node.html_node in previous_headings['h5'].subheadings:
-                    node.increment_title_tag(previous_headings['h5'])
+                else:
+                    for prev_heading_tag, prev_heading_node in previous_headings.items():
+                        if prev_heading_node and node.html_node in prev_heading_node.subheadings:
+                            node.increment_title_tag(prev_heading_node)
 
                 previous_headings[node.tag] = node
 

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -102,9 +102,9 @@ class Oscar:
             # If the previous and next node are skippable,
             # then skip this one too.
             if (previous_node
-                and len(nodes) > idx + 1
+                and len(self.nodes) > idx + 1
                 and previous_node.content_category in self.SKIP
-                and nodes[idx + 1].content_category in self.SKIP):
+                and self.nodes[idx + 1].content_category in self.SKIP):
                 continue
 
             # If this is a title, make sure headings are ordered correctly:

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -98,7 +98,7 @@ class Oscar:
 
         for idx, node in enumerate(nodes):
             # If this node is in a category that should be skipped
-            if node.content_category in self.SKIP:
+            if node.content_category in skip:
                 continue
 
             # If this node is a heading, and there's more
@@ -112,9 +112,9 @@ class Oscar:
             # If the previous and next node are skippable,
             # then skip this one too.
             if (previous_node
-                and len(self.nodes) > idx + 1
-                and previous_node.content_category in self.SKIP
-                and self.nodes[idx + 1].content_category in self.SKIP):
+                and len(nodes) > idx + 1
+                and previous_node.content_category in skip
+                and nodes[idx + 1].content_category in skip):
                 continue
 
             # If this is a heading, make sure it's ordered correctly:

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -88,7 +88,7 @@ class Oscar:
 
         for idx, node in enumerate(self.nodes):
             # If this node is in a category that should be skipped
-            if node.content_category in skip:
+            if node.content_category in self.SKIP:
                 continue
 
             # If this node is a title, and there's more
@@ -103,8 +103,8 @@ class Oscar:
             # then skip this one too.
             if (previous_node
                 and len(nodes) > idx + 1
-                and previous_node.content_category in skip
-                and nodes[idx + 1].content_category in skip):
+                and previous_node.content_category in self.SKIP
+                and nodes[idx + 1].content_category in self.SKIP):
                 continue
 
             # If this is a title, make sure headings are ordered correctly:

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -79,46 +79,24 @@ class Oscar:
         setval = []
 
         previous_node = None
-        previous_heading = None
+        previous_headings = {
+            'h2': None,
+            'h3': None,
+            'h4': None,
+            'h5': None
+        }
 
-        for idx, node in enumerate(self.nodes):
+        for idx, node in enumerate(nodes):
+            # If this node is in a category that should be skipped
+            if node.content_category in skip:
+                continue
+
             # If this node is a title, and there's more
             # content after it, and that content is skippable,
             # then skip this title. We don't want it.
             if (node.node_type == ContentNodeType.TITLE
                 and len(self.nodes) > idx + 1
                 and self.nodes[idx + 1].content_category in self.SKIP):
-                continue
-
-            # If this node is in a category that should be skipped
-            if node.content_category in self.SKIP:
-                continue
-
-<<<<<<< HEAD
-            # If this is a title, see if it's the right heading level
-            if node.node_type == ContentNodeType.TITLE and previous_node:
-                if previous_heading == None:
-                    node.tag = 'h2'
-                    setval.append(node)
-                    previous_heading = node
-                else:
-                    if previous_heading.content_category == node.content_category:
-                        node.increment_title_tag(previous_heading)
-                        setval.append(node)
-                        previous_heading = node
-=======
-            # If this is a title, make sure headings are ordered correctly:
-            if node.node_type == ContentNodeType.TITLE:
-                if node.tag == 'h1':
-                    # Don't allow h1's:
-                    node.change_tag('h2')
-                elif previous_heading and node.html_node in previous_heading.subheadings:
-                    # Enforce correct ordering of immediate subheadings:
-                    node.increment_title_tag(previous_heading)
-
-                retval.append(node)
-                previous_heading = node
-                previous_node = node
                 continue
 
             # If the previous and next node are skippable,
@@ -128,7 +106,24 @@ class Oscar:
                 and previous_node.content_category in skip
                 and nodes[idx + 1].content_category in skip):
                 continue
->>>>>>> 28b8fe6... WIP updating how heading incrementing works
+
+            # If this is a title, make sure headings are ordered correctly:
+            if node.node_type == ContentNodeType.TITLE:
+                # Don't allow h1's:
+                if node.tag == 'h1':
+                    node.change_tag('h2')
+                # Enforce correct ordering of immediate subheadings:
+                # TODO there is probably a cleaner way of doing this
+                elif previous_headings['h2'] and node.html_node in previous_headings['h2'].subheadings:
+                    node.increment_title_tag(previous_headings['h2'])
+                elif previous_headings['h3'] and node.html_node in previous_headings['h3'].subheadings:
+                    node.increment_title_tag(previous_headings['h3'])
+                elif previous_headings['h4'] and node.html_node in previous_headings['h4'].subheadings:
+                    node.increment_title_tag(previous_headings['h4'])
+                elif previous_headings['h5'] and node.html_node in previous_headings['h5'].subheadings:
+                    node.increment_title_tag(previous_headings['h5'])
+
+                previous_headings[node.tag] = node
 
             # By default, just add the node
             setval.append(node)

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -86,7 +86,7 @@ class Oscar:
             'h5': None
         }
 
-        for idx, node in enumerate(nodes):
+        for idx, node in enumerate(self.nodes):
             # If this node is in a category that should be skipped
             if node.content_category in skip:
                 continue

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -101,10 +101,10 @@ class Oscar:
             if node.content_category in self.SKIP:
                 continue
 
-            # If this node is a title, and there's more
+            # If this node is a heading, and there's more
             # content after it, and that content is skippable,
-            # then skip this title. We don't want it.
-            if (node.node_type == ContentNodeType.TITLE
+            # then skip this heading. We don't want it.
+            if (node.node_type == ContentNodeType.HEADING
                 and len(nodes) > idx + 1
                 and nodes[idx + 1].content_category in skip):
                 continue
@@ -117,8 +117,8 @@ class Oscar:
                 and self.nodes[idx + 1].content_category in self.SKIP):
                 continue
 
-            # If this is a title, make sure headings are ordered correctly:
-            if node.node_type == ContentNodeType.TITLE:
+            # If this is a heading, make sure it's ordered correctly:
+            if node.node_type == ContentNodeType.HEADING:
                 heading_assigned = False
 
                 # Don't allow h1's:
@@ -132,7 +132,7 @@ class Oscar:
                             if node.html_node in prev_heading_node.subheadings:
                                 # This heading is a subheading of the previous
                                 # heading node, so, increment it:
-                                node.increment_title_tag(prev_heading_node.tag)
+                                node.increment_heading_tag(prev_heading_node.tag)
                                 heading_assigned = True
                                 break
                             elif node.html_node in prev_heading_node.next_sibling_headings:
@@ -156,7 +156,7 @@ class Oscar:
                         if prev_heading_idx > heading_idx:
                             break
                         if not prev_heading_node:
-                            node.increment_title_tag('h{0}'.format(prev_heading_idx - 1))
+                            node.increment_heading_tag('h{0}'.format(prev_heading_idx - 1))
                             break
 
                 previous_headings[node.tag] = node


### PR DESCRIPTION
- Added properties to the `ContentNode` object that store the node's subheadings and next sibling headings.
- Updated Oscar to more accurately increment and re-assign heading tags based on previous headings' known subheadings and sibling headings.