### PR TITLE
Catalog import - More bugfixes and fine-tuning

### DIFF
--- a/programs/management/commands/import-catalog-data.py
+++ b/programs/management/commands/import-catalog-data.py
@@ -320,26 +320,30 @@ class Command(BaseCommand):
                 p.program.save()
 
                 # Create new program descriptions with the description provided in the matched catalog entry
-                description = ProgramDescription(
-                    description_type=description_type,
-                    description=self.get_description(
-                        matched_entry.id,
-                        matched_entry.catalog_id,
-                        is_graduate
-                    ),
-                    program=p.program
+                description_str = self.get_description(
+                    matched_entry.id,
+                    matched_entry.catalog_id,
+                    is_graduate
                 )
-                description.save()
+                if description_str:
+                    description = ProgramDescription(
+                        description_type=description_type,
+                        description=description_str,
+                        program=p.program
+                    )
+                    description.save()
 
-                description_full = ProgramDescription(
-                    description_type=description_type_full,
-                    description=self.get_description_full(
-                        matched_entry.id,
-                        p.program.catalog_url
-                    ),
-                    program=p.program
+                description_full_str = self.get_description_full(
+                    matched_entry.id,
+                    p.program.catalog_url
                 )
-                description_full.save()
+                if description_full_str:
+                    description_full = ProgramDescription(
+                        description_type=description_type_full,
+                        description=description_full_str,
+                        program=p.program
+                    )
+                    description_full.save()
 
                 # Increment match counts for all programs and for the matched catalog entry
                 match_count += 1

--- a/programs/management/commands/import-catalog-data.py
+++ b/programs/management/commands/import-catalog-data.py
@@ -499,6 +499,14 @@ class Command(BaseCommand):
         description_html = unicodedata.normalize('NFKC', description_html)
         description_html = description_html.replace('\u200b', '')
 
+        # Some of these descriptions have likely been through some sort
+        # of back-and-forth between encodings via copy+paste, and contain
+        # stray diacritics (e.g. "Â") not caught via filtering logic above.
+        # They were likely non-breaking space characters in a past life.
+        # https://stackoverflow.com/a/1462039
+        # Just get rid of them here:
+        description_html = description_html.replace('Â', '')
+
         # Other miscellaneous string replacements:
         description_html = re.sub(r'^(Program|Track) Description<p>', '<p>', description_html)
         description_html = re.sub('1Active-Visible.*', '', description_html)

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -343,16 +343,19 @@ class ContentNode(object):
         email_parsed = parseaddr(line)
         email_result = '@' in email_parsed[1]
 
-        # Is this line a common "subhead" for contact info?
-        common_contact_heading_result = line.lower() in [
+        # Is this line a common subhead-but-not-a-heading
+        # (e.g. a single line wrapped in <strong>) for contact info?
+        common_contact_subhead_result = line.lower() in [
             'mailing address',
-            'institution codes'
+            'institution codes',
+            'graduate fellowships',
+            'grad fellowships'
         ]
 
         if (
             phone_result
             or email_result
-            or mailing_address_result
+            or common_contact_subhead_result
             or (college_names and line.lower() in college_names)
             or (dept_names and line.lower() in dept_names)
         ):

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -343,9 +343,14 @@ class ContentNode(object):
         email_parsed = parseaddr(line)
         email_result = '@' in email_parsed[1]
 
+        # Is this line a common "Mailing Address"
+        # subhead?
+        mailing_address_result = line.lower() == 'mailing address'
+
         if (
             phone_result
             or email_result
+            or mailing_address_result
             or (college_names and line.lower() in college_names)
             or (dept_names and line.lower() in dept_names)
         ):

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -37,6 +37,7 @@ class ContentNode(object):
 
     PII_TYPES = [
         'NAME',
+        'PERSON',
         'PHONE',
         'ADDRESS',
         'EMAIL',

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -332,10 +332,10 @@ class ContentNode(object):
         """
         retval = False
 
-        # Is this line a phone number?
-        # NOTE: This check currently only tests against the basic
+        # Is this line a phone/fax number?
+        # NOTE: This check currently only tests against the basic phone
         # format 555-555-5555 (parentheses/spaces aren't accounted for)
-        phone_re = re.compile(r'^\d{3}\-\d{3}\-\d{4}$')
+        phone_re = re.compile(r'^((Telephone|Appointment Line|Fax)\: )?\d{3}\-\d{3}\-\d{4}$')
         phone_result = phone_re.fullmatch(line)
 
         # Is this line an email address?
@@ -343,9 +343,11 @@ class ContentNode(object):
         email_parsed = parseaddr(line)
         email_result = '@' in email_parsed[1]
 
-        # Is this line a common "Mailing Address"
-        # subhead?
-        mailing_address_result = line.lower() == 'mailing address'
+        # Is this line a common "subhead" for contact info?
+        common_contact_heading_result = line.lower() in [
+            'mailing address',
+            'institution codes'
+        ]
 
         if (
             phone_result

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -229,7 +229,10 @@ class ContentNode(object):
                             word_count = len(line[b_offset:e_offset].split(' '))
                             contact_info_score += entity['Score'] * word_count * 100
 
-        contact_info_avg = contact_info_score / total_words
+        try:
+            contact_info_avg = contact_info_score / total_words
+        except ZeroDivisionError:
+            contact_info_avg = 0
 
         # Finally, assign a content category:
         if contact_info_avg > 30:

--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -352,12 +352,19 @@ class ContentNode(object):
             'grad fellowships'
         ]
 
+        # Does this line look like a college or
+        # department name? (Useful as a fallback when
+        # we can't make an exact string match)
+        college_dept_re = re.compile(r'^(?:College of|Department of|Rosen College of) [a-zA-Z\ ]+$')
+        college_dept_result = college_dept_re.match(line)
+
         if (
             phone_result
             or email_result
             or common_contact_subhead_result
             or (college_names and line.lower() in college_names)
             or (dept_names and line.lower() in dept_names)
+            or college_dept_result
         ):
             retval = True
 

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -76,7 +76,7 @@ class Oscar:
         setval = []
 
         for node in self.nodes:
-            if node.name != 'br' and str(node.html_node).strip() != '':
+            if node.tag != 'br' and str(node.html_node).strip() != '':
                 setval.append(node)
 
         self.nodes = setval

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -76,7 +76,7 @@ class Oscar:
         setval = []
 
         for node in self.nodes:
-            if str(node.html_node).strip() != '':
+            if node.name != 'br' and str(node.html_node).strip() != '':
                 setval.append(node)
 
         self.nodes = setval


### PR DESCRIPTION
- Miscellaneous bugfixes:
  - Ensure empty `ProgramDescription` objects aren't created if a retrieved/sanitized description string is empty.
  - Added failsafe for division by zero when calculating average contact info scores for a node.
  - Updated Oscar to ignore top-level `<br>` tags (`<br>`s within paragraphs remain intact).
  - Added note and filtering of garbage characters that likely result from mismatched character encodings.
- Contact info extraction fine-tuning:
  - Added `PERSON` to allowed `PII_TYPES` for contact info extraction (Comprehend's base entity detection API labels things that look like person names as `PERSON`, unlike the PII entity detection, which uses `NAME`.)
  - Added more string matches and regex checks for lines that look like blocks of contact info.