### PR TITLE
Catalog content filtering improvements

### DIFF
--- a/programs/management/commands/import-catalog-data.py
+++ b/programs/management/commands/import-catalog-data.py
@@ -486,6 +486,13 @@ class Command(BaseCommand):
                         nested_tag.name = 'span'
                         nested_tag.attrs = []
 
+                # Remove relative links, and links with no href
+                if not strip_links and match.name == 'a':
+                    href = match.get('href')
+                    if not href or not href.startswith(('http', 'mailto', 'tel')):
+                        match.name = 'span'
+                        match.attrs = []
+
                 if match.name not in tag_whitelist:
                     # Filter out tags not in our whitelist (replace them with span's)
                     match.name = 'span'

--- a/programs/management/commands/import-catalog-data.py
+++ b/programs/management/commands/import-catalog-data.py
@@ -527,7 +527,7 @@ class Command(BaseCommand):
         p_tags = description_html.find_all(lambda tag: tag.name == 'p' and not tag.find(['ul', 'ol', 'dl', 'table']))
         for p_tag in p_tags:
             p_str = str(p_tag).replace('<p>', '').replace('</p>', '')
-            substrings = re.split(r'<br[\s]?[\/]?>[\s]*<br[\s]?[\/]?>', p_str)
+            substrings = re.split(r'(?:<br[\s]?[\/]?>[\s]*){2}', p_str)
             if len(substrings) > 1:
                 substring_inserted = False
                 for substring in substrings:

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -1,7 +1,6 @@
 import boto3
 from bs4 import BeautifulSoup
 import settings
-import re
 
 from programs.utilities.content_node import ContentNode, ContentNodeType, ContentCategory
 from io import StringIO
@@ -65,28 +64,8 @@ class Oscar:
         soup = BeautifulSoup(self.description, 'html.parser')
 
         for node in soup.contents:
-            subnodes = []
-            # These p tags _shouldn't_ have nested elements like these,
-            # but just in case, make sure we ignore them:
-            if node.name == 'p' and not node.find(['ul', 'ol', 'dl', 'table']):
-                # If this is a paragraph node, split the node
-                # by subsequent <br> tags (<br><br>) and transform each
-                # split chunk into its own new paragraph node:
-                node_str = str(node).replace('<p>', '').replace('</p>', '')
-                substrings = re.split(r'<br[\s]?[\/]?>[\s]?<br[\s]?[\/]?>', node_str)
-                if len(substrings) > 1:
-                    for substring in substrings:
-                        new_p = BeautifulSoup('<p>{0}</p>'.format(substring), 'html.parser')
-                        new_p = new_p.find('p')
-                        subnodes.append(new_p)
-                else:
-                    subnodes = [node]
-            else:
-                subnodes = [node]
-
-            for subnode in subnodes:
-                content_node = ContentNode(subnode, self.client)
-                self.nodes.append(content_node)
+            content_node = ContentNode(node, self.client)
+            self.nodes.append(content_node)
 
         self.__remove_empty()
 

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -69,10 +69,9 @@ class Oscar:
             # These p tags _shouldn't_ have nested elements like these,
             # but just in case, make sure we ignore them:
             if node.name == 'p' and not node.find(['ul', 'ol', 'dl', 'table']):
-                # If this is a paragraph node, and the node contains
-                # two subsequent <br> tags (<br><br>), split the node
-                # and transform each split chunk into its own new
-                # paragraph node:
+                # If this is a paragraph node, split the node
+                # by subsequent <br> tags (<br><br>) and transform each
+                # split chunk into its own new paragraph node:
                 node_str = str(node).replace('<p>', '').replace('</p>', '')
                 substrings = re.split(r'<br[\s]?[\/]?>[\s]?<br[\s]?[\/]?>', node_str)
                 if len(substrings) > 1:

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -1,6 +1,7 @@
 import boto3
 from bs4 import BeautifulSoup
 import settings
+import re
 
 from programs.utilities.content_node import ContentNode, ContentNodeType, ContentCategory
 from io import StringIO
@@ -64,8 +65,29 @@ class Oscar:
         soup = BeautifulSoup(self.description, 'html.parser')
 
         for node in soup.contents:
-            content_node = ContentNode(node, self.client)
-            self.nodes.append(content_node)
+            subnodes = []
+            # These p tags _shouldn't_ have nested elements like these,
+            # but just in case, make sure we ignore them:
+            if node.name == 'p' and not node.find(['ul', 'ol', 'dl', 'table']):
+                # If this is a paragraph node, and the node contains
+                # two subsequent <br> tags (<br><br>), split the node
+                # and transform each split chunk into its own new
+                # paragraph node:
+                node_str = str(node).replace('<p>', '').replace('</p>', '')
+                substrings = re.split(r'<br[\s]?[\/]?>[\s]?<br[\s]?[\/]?>', node_str)
+                if len(substrings) > 1:
+                    for substring in substrings:
+                        new_p = BeautifulSoup('<p>{0}</p>'.format(substring), 'html.parser')
+                        new_p = new_p.find('p')
+                        subnodes.append(new_p)
+                else:
+                    subnodes = [node]
+            else:
+                subnodes = [node]
+
+            for subnode in subnodes:
+                content_node = ContentNode(subnode, self.client)
+                self.nodes.append(content_node)
 
         self.__remove_empty()
 


### PR DESCRIPTION
Fixes and improvements to catalog description content sanitization:
- Added logic that translates double line breaks (`<br><br>`) into individual paragraphs.
    - Before: `<p>abc<br><br>def</p>`
    - After: `<p>abc</p><p>def</p>`

  Helps resolve issues with some contact info in catalog descriptions bleeding into the first paragraph of the description's introduction, and ensures those chunks are filtered for contact data separately.
- Added logic that removes nested like elements.
     - Before: `<em>abc<em>def</em></em>`
     - After: `<em>abcdef</em>`

  This helps reduce the likelihood of poorly-formatted markup impacting how lines of text within nodes are determined, thus improving the accuracy of contact data filtering.
- Added logic that removes inline elements, like `<em>` and `<strong>`, that completely surround the inner contents of a heading (are used strictly for text formatting).
    - Before: `<h2><strong>...</strong></h2>`
    - After: `<h2>...</h2>`
- Added logic that removes links with relative URLs (assuming `strip_links` is False/we're processing a short description)

Other:
- Updated out-of-date Beautiful Soup function call `.findAll` to `.find_all`