### PR TITLE
Removal of tables from short catalog descriptions; fixed retrieval of program descriptions on tracks

### DIFF
--- a/programs/management/commands/import-catalog-descriptions.py
+++ b/programs/management/commands/import-catalog-descriptions.py
@@ -60,6 +60,40 @@ class CatalogEntry(object):
         self.match_count = 0
 
     @property
+    def description(self):
+        """
+        Returns an unmodified catalog program description
+
+        Returns:
+            (str): Catalog description string
+        """
+        desc = ''
+
+        if 'programDescription' in self.data:
+            # Catalog programs store this value in `programDescription`
+            desc = self.data['programDescription']
+        elif 'description' in self.data:
+            # Catalog tracks store this value in `description`
+            desc = self.data['description']
+
+        return desc
+
+    @property
+    def curriculum(self):
+        """
+        Returns an unmodified catalog curriculum
+
+        Returns:
+            (str): Catalog curriculum string
+        """
+        curriculum = ''
+
+        if 'requiredCoreCourses' in self.data:
+            curriculum = self.data['requiredCoreCourses']
+
+        return curriculum
+
+    @property
     def level(self):
         try:
             temp_level = Level.objects.get(name=self.type)
@@ -430,9 +464,9 @@ class Command(BaseCommand):
         """
         retval = ''
 
-        if 'programDescription' in catalog_entry.data:
+        if catalog_entry.description:
             retval = self.sanitize_description(
-                description_str=catalog_entry.data['programDescription'],
+                description_str=catalog_entry.description,
                 strip_tables=True
             )
 
@@ -448,16 +482,16 @@ class Command(BaseCommand):
         """
         retval = ''
 
-        if 'programDescription' in catalog_entry.data:
+        if catalog_entry.description:
             retval += self.sanitize_description(
-                description_str=catalog_entry.data['programDescription'],
+                description_str=catalog_entry.description,
                 unwrap_links=True,
                 strip_tables=True
             )
 
-        if 'requiredCoreCourses' in catalog_entry.data:
+        if catalog_entry.curriculum:
             retval += self.sanitize_description(
-                description_str=catalog_entry.data['requiredCoreCourses'],
+                description_str=catalog_entry.curriculum,
                 unwrap_links=True
             )
 

--- a/programs/management/commands/import-catalog-descriptions.py
+++ b/programs/management/commands/import-catalog-descriptions.py
@@ -431,7 +431,10 @@ class Command(BaseCommand):
         retval = ''
 
         if 'programDescription' in catalog_entry.data:
-            retval = self.sanitize_description(catalog_entry.data['programDescription'])
+            retval = self.sanitize_description(
+                description_str=catalog_entry.data['programDescription'],
+                strip_tables=True
+            )
 
         return retval
 
@@ -446,14 +449,21 @@ class Command(BaseCommand):
         retval = ''
 
         if 'programDescription' in catalog_entry.data:
-            retval += self.sanitize_description(catalog_entry.data['programDescription'], True)
+            retval += self.sanitize_description(
+                description_str=catalog_entry.data['programDescription'],
+                unwrap_links=True,
+                strip_tables=True
+            )
 
         if 'requiredCoreCourses' in catalog_entry.data:
-            retval += self.sanitize_description(catalog_entry.data['requiredCoreCourses'], True)
+            retval += self.sanitize_description(
+                description_str=catalog_entry.data['requiredCoreCourses'],
+                unwrap_links=True
+            )
 
         return retval
 
-    def sanitize_description(self, description_str, strip_links=False):
+    def sanitize_description(self, description_str, unwrap_links=False, strip_tables=False):
         """
         Modifies the provided catalog description string
         to clean up markup and strip undesired tags/content.
@@ -461,12 +471,13 @@ class Command(BaseCommand):
         tag_whitelist = [
             'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
             'p', 'br', 'pre', 'sup', 'sub',
-            'table', 'tbody', 'thead', 'tr', 'td',
             'ul', 'li', 'ol', 'dl', 'dt', 'dd',
             'b', 'em', 'i', 'strong', 'u'
         ]
-        if not strip_links:
+        if not unwrap_links:
             tag_whitelist.append('a')
+        if not strip_tables:
+            tag_whitelist.extend(['table', 'tbody', 'thead', 'tr', 'td'])
 
         # Tags that should not allow nesting of the same
         # tag type (e.g. <em><em>...</em></em>),
@@ -489,13 +500,19 @@ class Command(BaseCommand):
         for empty_tag in empty_tags:
             empty_tag.decompose()
 
+        # Strip tables, if enabled:
+        if strip_tables:
+            table_tags = description_html.find_all('table')
+            for table_tag in table_tags:
+                table_tag.decompose()
+
         for match in description_html.descendants:
             if isinstance(match, NavigableString) == False:
                 # Transform <u> tags to <em>
                 if match.name == 'u':
                     match.name = 'em'
 
-                # Strip <p> tags within <li>s
+                # Unwrap <p> tags within <li>s
                 if match.name == 'p' and match.parent.name == 'li':
                     match.name = 'span'
                     match.attrs = []
@@ -508,14 +525,14 @@ class Command(BaseCommand):
                         nested_tag.name = 'span'
                         nested_tag.attrs = []
 
-                # Remove relative links, and links with no href
-                if not strip_links and match.name == 'a':
+                # Unwrap relative links, and links with no href
+                if not unwrap_links and match.name == 'a':
                     href = match.get('href')
                     if not href or not href.startswith(('http', 'mailto', 'tel')):
                         match.name = 'span'
                         match.attrs = []
 
-                # Remove inline tags in nested_tag_blacklist that
+                # Unwrap inline tags in nested_tag_blacklist that
                 # surround all content within headings
                 if match.name in heading_tags:
                     inner_tag = match.find(nested_tag_blacklist)


### PR DESCRIPTION
- Added an option to `sanitize_description()` in the catalog importer to remove tables from the passed in description string.  Also updated references to 'strip' vs 'unwrap' for clarification.  Short catalog descriptions now use this option in order to remove metadata tables at the top of all graduate catalog descriptions.
- Fixed retrieval of program descriptions on catalog tracks, which are stored in `description` fields rather than `programDescription`