### PR TITLE
Allow tables in description content to have empty td, th cells

### DIFF
--- a/programs/management/commands/import-catalog-descriptions.py
+++ b/programs/management/commands/import-catalog-descriptions.py
@@ -530,7 +530,7 @@ class Command(BaseCommand):
         description_html = BeautifulSoup(description_str, 'html.parser')
 
         # Strip empty tags:
-        empty_tags = description_html.find_all(lambda tag: (not tag.contents or len(tag.get_text(strip=True)) <= 0) and not tag.name == 'br')
+        empty_tags = description_html.find_all(lambda tag: (not tag.contents or len(tag.get_text(strip=True)) <= 0) and not tag.name in ['br', 'td', 'th'])
         for empty_tag in empty_tags:
             empty_tag.decompose()
 


### PR DESCRIPTION
See title.  Existing logic was allowing cells in application deadline tables in the full catalog descriptions to be removed completely, resulting in incorrect cell assignment per column for other cells with content.  Allowing empty table cells ensures cell ordering is preserved.