### PR TITLE
Initial structured catalog data support

### DIFF
--- a/programs/management/commands/import-catalog-descriptions.py
+++ b/programs/management/commands/import-catalog-descriptions.py
@@ -231,7 +231,8 @@ Finished in {datetime.now() - self.start_time}
             response = requests.get(
                 path,
                 params=params,
-                headers=headers
+                headers=headers,
+                timeout=15 # courses request can be slow
             )
 
             data = response.json()
@@ -262,7 +263,7 @@ Finished in {datetime.now() - self.start_time}
         for result in data:
             self.catalog_courses_prep_progress.next()
             if 'pid' in result:
-                self.catalog_courses[result.pid] = result
+                self.catalog_courses[result['pid']] = result
 
     def __get_catalog_entries(self):
         """

--- a/programs/management/commands/import-catalog-descriptions.py
+++ b/programs/management/commands/import-catalog-descriptions.py
@@ -681,9 +681,14 @@ Finished in {datetime.now() - self.start_time}
 
             if catalog_entry:
                 # Update the catalog URL of the program
+                catalog_id_path = catalog_entry.data['pid']
+                if 'inheritedFrom' in catalog_entry.data:
+                    # Tracks use a path that looks like
+                    # /programs/[parent pid]/[track pid]:
+                    catalog_id_path = f"{catalog_entry.data['inheritedFrom']}/{catalog_id_path}"
                 mp.program.catalog_url = self.catalog_url.format(
                     catalog_entry.data['academicLevel'],
-                    catalog_entry.data['pid']
+                    catalog_id_path
                 )
                 mp.program.save()
 

--- a/programs/management/commands/import-catalog-descriptions.py
+++ b/programs/management/commands/import-catalog-descriptions.py
@@ -1002,6 +1002,13 @@ Finished in {datetime.now() - self.start_time}
         # BS seems to have a hard time with doing this in-place, so perform
         # a second loop to remove the garbage tags
         for span_match in description_html.find_all('span'):
+            # If this span is followed by another subsequent span,
+            # add a space to the end of its inner contents (to avoid
+            # awkward abutting contents)
+            if span_match.next_sibling and span_match.next_sibling.name == 'span':
+                span_match.insert_after(' ')
+
+            # Finally, unwrap the tag:
             span_match.unwrap()
 
         # Split paragraph tag contents by subsequent <br> tags (<br><br>)

--- a/programs/utilities/catalog_match.py
+++ b/programs/utilities/catalog_match.py
@@ -9,10 +9,11 @@ class CatalogEntry(object):
     Describes a catalog program or track and
     its associated data.
     """
-    def __init__(self, json, program_type, college_short):
+    def __init__(self, json, program_type, college_short, curriculum_courses):
         self.data = json
         self.type = program_type
         self.college_short = college_short
+        self.curriculum_courses = curriculum_courses
         self.match_count = 0
         self.program_description_clean = None
         self.program_curriculum_clean = None
@@ -41,7 +42,7 @@ class CatalogEntry(object):
     @property
     def curriculum(self):
         """
-        Returns an unmodified catalog curriculum
+        Returns an original catalog curriculum string
 
         Returns:
             (str): Catalog curriculum string
@@ -52,23 +53,25 @@ class CatalogEntry(object):
         # actively in use.  Assume this field is in use if at least one
         # object under `groupings` is present, and that it has a non-empty
         # `label` and `rules`:
-        hasDegreeRequirements = False
+        has_degree_requirements = False
         try:
-            firstGrouping = self.data['degreeRequirements']['groupings'][0]
-            firstGroupingLabel = firstGrouping['label']
-            if firstGroupingLabel != '' and 'rules' in firstGrouping:
-                hasDegreeRequirements = True
+            first_grouping = self.data['degreeRequirements']['groupings'][0]
+            first_grouping_label = first_grouping['label']
+            if first_grouping_label != '' and 'rules' in first_grouping:
+                has_degree_requirements = True
         except KeyError:
             pass
 
-        if hasDegreeRequirements:
+        if has_degree_requirements:
             # This program is now utilizing dedicated fields
             # for portions of the larger "curriculum" content.
             # Piece them all together:
+            degree_requirements = self.__get_degree_requirements_html()
+
             if 'programPrerequisites' in self.data:
                 curriculum += f"<h2>Program Prerequisites</h2>{self.data['programPrerequisites']}"
 
-            # TODO degree requirements
+            curriculum += f"<h2>Degree Requirements</h2>{degree_requirements}"
 
             if 'applicationRequirements' in self.data:
                 curriculum += f"<h2>Application Requirements</h2>{self.data['applicationRequirements']}"
@@ -151,6 +154,14 @@ class CatalogEntry(object):
                 MatchableProgram match exists
         """
         return self.match_count > 0
+
+    def __get_degree_requirements_html(self):
+        """
+        Returns a content string suitable for use in this
+        entry's curriculum HTML to describe degree requirements.
+        """
+        # TODO
+        return ''
 
 
 class MatchableProgram(object):

--- a/programs/utilities/catalog_match.py
+++ b/programs/utilities/catalog_match.py
@@ -54,18 +54,22 @@ class CatalogEntry(object):
         # data are in use if `degreeRequirements` is present in
         # self.html_data and is not empty:
         if 'degreeRequirements' in self.html_data and self.html_data['degreeRequirements'] != '':
+            # NOTE: Headings starting at h1 are intentional here.
+            # Headings in fields in `data_html` tend to start at h2,
+            # so by using h1s here, we allow Oscar to determine
+            # proper heading order and fix things later:
             if 'programPrerequisites' in self.data:
-                curriculum += f"<h2>Program Prerequisites</h2>{self.data['programPrerequisites']}"
+                curriculum += f"<h1>Program Prerequisites</h1>{self.data['programPrerequisites']}"
             elif 'trackPrerequisites' in self.data:
-                curriculum += f"<h2>Track Prerequisites</h2>{self.data['trackPrerequisites']}"
+                curriculum += f"<h1>Track Prerequisites</h1>{self.data['trackPrerequisites']}"
 
-            curriculum += f"<h2>Degree Requirements</h2>{self.html_data['degreeRequirements']}"
+            curriculum += f"<h1>Degree Requirements</h1>{self.html_data['degreeRequirements']}"
 
             if 'applicationRequirements' in self.data:
-                curriculum += f"<h2>Application Requirements</h2>{self.data['applicationRequirements']}"
+                curriculum += f"<h1>Application Requirements</h1>{self.data['applicationRequirements']}"
 
             if 'applicationDeadlineText' in self.data:
-                curriculum += f"<h2>Application Deadlines</h2>{self.data['applicationDeadlineText']}"
+                curriculum += f"<h1>Application Deadlines</h1>{self.data['applicationDeadlineText']}"
 
                 if 'applicationDeadlinesNotes' in self.data:
                     curriculum += self.data['applicationDeadlinesNotes']
@@ -73,13 +77,13 @@ class CatalogEntry(object):
                     curriculum += self.data['applicationNotesTrack']
 
             if 'financialInformation' in self.data:
-                curriculum += f"<h2>Financial Information</h2>{self.data['financialInformation']}"
+                curriculum += f"<h1>Financial Information</h1>{self.data['financialInformation']}"
 
             if 'fellowshipInformation' in self.data:
-                curriculum += f"<h2>Fellowship Information</h2>{self.data['fellowshipInformation']}"
+                curriculum += f"<h1>Fellowship Information</h1>{self.data['fellowshipInformation']}"
 
             if 'licensureDisclosureNotes' in self.data and 'licensureDisclosure' in self.data and self.data['licensureDisclosure'] == True:
-                curriculum += f"<h2>UCF Online</h2>{self.data['licensureDisclosureNotes']}"
+                curriculum += f"<h1>UCF Online</h1>{self.data['licensureDisclosureNotes']}"
         elif 'requiredCoreCourses' in self.data:
             curriculum = self.data['requiredCoreCourses']
 

--- a/programs/utilities/catalog_match.py
+++ b/programs/utilities/catalog_match.py
@@ -53,16 +53,16 @@ class CatalogEntry(object):
         # actively in use.  Assume this field is in use if at least one
         # object under `groupings` is present, and that it has a non-empty
         # `label` and `rules`:
-        has_degree_requirements = False
+        has_structured_degree_requirements = False
         try:
             first_grouping = self.data['degreeRequirements']['groupings'][0]
             first_grouping_label = first_grouping['label']
             if first_grouping_label != '' and 'rules' in first_grouping:
-                has_degree_requirements = True
+                has_structured_degree_requirements = True
         except KeyError:
             pass
 
-        if has_degree_requirements:
+        if has_structured_degree_requirements:
             # This program is now utilizing dedicated fields
             # for portions of the larger "curriculum" content.
             # Piece them all together:
@@ -70,15 +70,28 @@ class CatalogEntry(object):
 
             if 'programPrerequisites' in self.data:
                 curriculum += f"<h2>Program Prerequisites</h2>{self.data['programPrerequisites']}"
+            elif 'trackPrerequisites' in self.data:
+                curriculum += f"<h2>Track Prerequisites</h2>{self.data['trackPrerequisites']}"
 
             curriculum += f"<h2>Degree Requirements</h2>{degree_requirements}"
 
             if 'applicationRequirements' in self.data:
                 curriculum += f"<h2>Application Requirements</h2>{self.data['applicationRequirements']}"
+
             if 'applicationDeadlineText' in self.data:
                 curriculum += f"<h2>Application Deadlines</h2>{self.data['applicationDeadlineText']}"
+
+            if 'applicationDeadlinesNotes' in self.data:
+                curriculum += self.data['applicationDeadlinesNotes']
+            elif 'applicationNotesTrack' in self.data:
+                curriculum += self.data['applicationNotesTrack']
+
             if 'financialInformation' in self.data:
                 curriculum += f"<h2>Financial Information</h2>{self.data['financialInformation']}"
+
+            if 'fellowshipInformation' in self.data:
+                curriculum += f"<h2>Fellowship Information</h2>{self.data['fellowshipInformation']}"
+
             if 'licensureDisclosureNotes' in self.data and 'licensureDisclosure' in self.data and self.data['licensureDisclosure'] == True:
                 curriculum += f"<h2>Licensure Disclosure</h2>{self.data['licensureDisclosureNotes']}"
         elif 'requiredCoreCourses' in self.data:
@@ -161,7 +174,9 @@ class CatalogEntry(object):
         entry's curriculum HTML to describe degree requirements.
         """
         # TODO
-        return ''
+        html = ''
+
+        return html
 
 
 class MatchableProgram(object):

--- a/programs/utilities/catalog_match.py
+++ b/programs/utilities/catalog_match.py
@@ -9,12 +9,11 @@ class CatalogEntry(object):
     Describes a catalog program or track and
     its associated data.
     """
-    def __init__(self, json, html_data, program_type, college_short, curriculum_courses):
+    def __init__(self, json, html_data, program_type, college_short):
         self.data = json
         self.html_data = html_data
         self.type = program_type
         self.college_short = college_short
-        self.curriculum_courses = curriculum_courses
         self.match_count = 0
         self.program_description_clean = None
         self.program_curriculum_clean = None

--- a/programs/utilities/catalog_match.py
+++ b/programs/utilities/catalog_match.py
@@ -73,7 +73,8 @@ class CatalogEntry(object):
             elif 'trackPrerequisites' in self.data:
                 curriculum += f"<h2>Track Prerequisites</h2>{self.data['trackPrerequisites']}"
 
-            curriculum += f"<h2>Degree Requirements</h2>{degree_requirements}"
+            if degree_requirements:
+                curriculum += f"<h2>Degree Requirements</h2>{degree_requirements}"
 
             if 'applicationRequirements' in self.data:
                 curriculum += f"<h2>Application Requirements</h2>{self.data['applicationRequirements']}"
@@ -81,10 +82,10 @@ class CatalogEntry(object):
             if 'applicationDeadlineText' in self.data:
                 curriculum += f"<h2>Application Deadlines</h2>{self.data['applicationDeadlineText']}"
 
-            if 'applicationDeadlinesNotes' in self.data:
-                curriculum += self.data['applicationDeadlinesNotes']
-            elif 'applicationNotesTrack' in self.data:
-                curriculum += self.data['applicationNotesTrack']
+                if 'applicationDeadlinesNotes' in self.data:
+                    curriculum += self.data['applicationDeadlinesNotes']
+                elif 'applicationNotesTrack' in self.data:
+                    curriculum += self.data['applicationNotesTrack']
 
             if 'financialInformation' in self.data:
                 curriculum += f"<h2>Financial Information</h2>{self.data['financialInformation']}"

--- a/programs/utilities/catalog_match.py
+++ b/programs/utilities/catalog_match.py
@@ -48,7 +48,37 @@ class CatalogEntry(object):
         """
         curriculum = ''
 
-        if 'requiredCoreCourses' in self.data:
+        # Determine if the structured `degreeRequirements` field is
+        # actively in use.  Assume this field is in use if at least one
+        # object under `groupings` is present, and that it has a non-empty
+        # `label` and `rules`:
+        hasDegreeRequirements = False
+        try:
+            firstGrouping = self.data['degreeRequirements']['groupings'][0]
+            firstGroupingLabel = firstGrouping['label']
+            if firstGroupingLabel != '' and 'rules' in firstGrouping:
+                hasDegreeRequirements = True
+        except KeyError:
+            pass
+
+        if hasDegreeRequirements:
+            # This program is now utilizing dedicated fields
+            # for portions of the larger "curriculum" content.
+            # Piece them all together:
+            if 'programPrerequisites' in self.data:
+                curriculum += f"<h2>Program Prerequisites</h2>{self.data['programPrerequisites']}"
+
+            # TODO degree requirements
+
+            if 'applicationRequirements' in self.data:
+                curriculum += f"<h2>Application Requirements</h2>{self.data['applicationRequirements']}"
+            if 'applicationDeadlineText' in self.data:
+                curriculum += f"<h2>Application Deadlines</h2>{self.data['applicationDeadlineText']}"
+            if 'financialInformation' in self.data:
+                curriculum += f"<h2>Financial Information</h2>{self.data['financialInformation']}"
+            if 'licensureDisclosureNotes' in self.data and 'licensureDisclosure' in self.data and self.data['licensureDisclosure'] == True:
+                curriculum += f"<h2>Licensure Disclosure</h2>{self.data['licensureDisclosureNotes']}"
+        elif 'requiredCoreCourses' in self.data:
             curriculum = self.data['requiredCoreCourses']
 
         return curriculum


### PR DESCRIPTION
- Updated the catalog importer to support new structured fields in Kuali for more discrete chunks of curriculum-related content.  `CatalogEntry.curriculum` has been modified to return a combination of these new fields if they're in use, or to continue to return the `requiredCoreCourses` field value if not.
- To support the bullet point above, a new fetch for all catalog IDs has been added (`__get_catalogs()`) early in the import process, as well as calls to per-program endpoints for pre-generated HTML (intended for Kuali's frontend, which we're borrowing for degree requirements in the big "curriculum" block).  I'm open to suggestions on how to re-work where this fetch occurs and potentially implement threading for a future PR.
- Updated `__sanitize_description()` to better support HTML coming from the pre-generated HTML endpoints noted in the bullet point above:
  - Remove all data attributes from all elements
  - Strip the litany of `<!-- -->` comments that show up in this HTML
  - Add spaces between subsequent `<span>`-wrapped content

Other:
- Fixed generation of catalog URLs for tracks to ensure parent PID and track PID are both included in the generated URL path