### PR TITLE
Catalog importer - JSON fetch hardening; removal of display-related content from descriptions

### DIFF
--- a/programs/utilities/content_node.py
+++ b/programs/utilities/content_node.py
@@ -21,6 +21,7 @@ class ContentCategory(Enum):
     ADMISSIONS = 'Admissions Info'
     COURSES = 'Course Info'
     CONTACT_INFO = 'Contact Info'
+    DISPLAY = 'Display-related Content'
 
 #endregion
 
@@ -251,6 +252,8 @@ class ContentNode(object):
         # Finally, assign a content category:
         if contact_info_avg > 30:
             self.content_category = ContentCategory.CONTACT_INFO
+        elif any([x in self.cleaned_str.lower() for x in ['scroll to', 'scroll down', 'scroll up']]):
+            self.content_category = ContentCategory.DISPLAY
         elif any([x in self.cleaned_str.lower() for x in ['credit hour', 'course', 'elective']]):
             self.content_category = ContentCategory.COURSES
         elif any([x in self.cleaned_str.lower() for x in ['admission']]):

--- a/programs/utilities/oscar.py
+++ b/programs/utilities/oscar.py
@@ -23,7 +23,8 @@ class Oscar:
     #region Shared Class Variables
 
     SKIP = [
-        ContentCategory.CONTACT_INFO
+        ContentCategory.CONTACT_INFO,
+        ContentCategory.DISPLAY
     ]
 
     #endregion


### PR DESCRIPTION
JSON fetch hardening (`__get_json_response()`):
- Added request timeout of 15s to `__get_json_response()`
- Added `response.raise_for_status()` in the main `try` block to ensure an actual `HTTPError` can be caught when one occurs.  Previously, the only error you'd see logged would be related to `response.json()` bombing, due to 400/500 errors not returning JSON-like content.
- Updated `__get_json_response()` to re-try fetching data if an initial fetch failed.  Kuali's front-facing endpoints notoriously return intermittent 502s; this update should give us the best chance at avoiding data loss due to these random errors.
- `__get_json_response()` will now always return _something_, even if it's `None`.
 
Removal of display-related content from descriptions:
- Added the `DISPLAY` `ContentCategory` for Oscar to ignore.  This category is intended to catch blurbs that reference the position or display of other content on Kuali's front-facing catalog views (e.g. "Please scroll to X section for more info..."), which may be incorrect when shown outside of the context of Kuali.