### PR TITLE
Staff Serializer

### DIFF
--- a/research/serializers.py
+++ b/research/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from research.models import *
-from teledata.serializers import StaffSerializer
+from teledata.serializers import StaffContactSerializer
 
 class ResearcherEducationSerializer(serializers.ModelSerializer):
     class Meta:
@@ -143,7 +143,7 @@ class ClinicalTrialSerializer(serializers.ModelSerializer):
         model = ClinicalTrial
 
 class ResearcherSerializer(serializers.ModelSerializer):
-    teledata_record = StaffSerializer(many=False, read_only=True)
+    teledata_record = StaffContactSerializer(many=False, read_only=True)
     education = ResearcherEducationSerializer(many=True, read_only=True)
     books = serializers.HyperlinkedIdentityField(
         view_name='api.researcher.books.list',

--- a/teledata/serializers.py
+++ b/teledata/serializers.py
@@ -67,6 +67,14 @@ class DepartmentSerializer(serializers.ModelSerializer):
         model = Department
 
 
+class StaffContactSerializer(serializers.ModelSerializer):
+    class Meta:
+        fields = [
+            'email',
+            'phone'
+        ]
+        model = Staff
+
 class StaffSerializer(serializers.ModelSerializer):
     dept = DepartmentLinkSerializer(
         many=False,


### PR DESCRIPTION
Enhancements:
* Added a new simplified serializer for staff records that only includes email and phone.
* Updated the serializer used for the `teledata_record` field on the `ResearcherSerializer` to use the simplified version.