### PR TITLE
Adds employee information to researchers API endpoint

### DIFF
--- a/research/models.py
+++ b/research/models.py
@@ -27,11 +27,13 @@ class Researcher(models.Model):
 
     @property
     def name_formatted_title(self):
-        title = self.employee_record.prefix.strip()
+        retval = ''
+        if self.employee_record.prefix:
+            title = self.employee_record.prefix.strip()
+            title += '.' if title.endswith('.') == False else ''
 
-        title += '.' if title.endswith('.') == False else ''
+            retval += f"{title} " if 'dr' in title.lower() else ''
 
-        retval = f"{title} " if 'dr' in title.lower() else ''
         retval += f"{self.employee_record.first_name} {self.employee_record.last_name}"
 
         return retval

--- a/research/models.py
+++ b/research/models.py
@@ -13,30 +13,32 @@ class Researcher(models.Model):
 
     def __unicode__(self):
         return '{0}, {1} - {2}'.format(
-            self.teledata_record.last_name,
-            self.teledata_record.first_name,
-            self.orcid_id
+            self.employee_record.last_name,
+            self.employee_record.first_name,
+            self.employee_record.ext_employee_id
         )
 
     def __str__(self):
         return '{0}, {1} - {2}'.format(
-            self.teledata_record.last_name,
-            self.teledata_record.first_name,
-            self.orcid_id
+            self.employee_record.last_name,
+            self.employee_record.first_name,
+            self.employee_record.ext_employee_id
         )
 
     @property
     def name_formatted_title(self):
-        title = self.teledata_record.name_title.strip()
+        title = self.employee_record.prefix.strip()
 
-        retval = f"{title} " if title== 'Dr.' else ''
-        retval += f"{self.teledata_record.first_name} {self.teledata_record.last_name}"
+        title += '.' if title.endswith('.') == False else ''
+
+        retval = f"{title} " if 'dr' in title.lower() else ''
+        retval += f"{self.employee_record.first_name} {self.employee_record.last_name}"
 
         return retval
 
     @property
     def name_formatted_no_title(self):
-        return f"{self.teledata_record.first_name} {self.teledata_record.last_name}"
+        return f"{self.employee_record.first_name} {self.employee_record.last_name}"
 
 class ResearcherEducation(models.Model):
     researcher = models.ForeignKey(Researcher, on_delete=models.CASCADE, related_name='education')

--- a/research/serializers.py
+++ b/research/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from research.models import *
 from teledata.serializers import StaffContactSerializer
+from units.serializers import EmployeeSerializer
 
 class ResearcherEducationSerializer(serializers.ModelSerializer):
     class Meta:
@@ -144,6 +145,7 @@ class ClinicalTrialSerializer(serializers.ModelSerializer):
 
 class ResearcherSerializer(serializers.ModelSerializer):
     teledata_record = StaffContactSerializer(many=False, read_only=True)
+    employee_record = EmployeeSerializer(many=False, read_only=True)
     education = ResearcherEducationSerializer(many=True, read_only=True)
     books = serializers.HyperlinkedIdentityField(
         view_name='api.researcher.books.list',
@@ -186,6 +188,7 @@ class ResearcherSerializer(serializers.ModelSerializer):
             'name_formatted_no_title',
             'biography',
             'teledata_record',
+            'employee_record',
             'education',
             'books',
             'articles',

--- a/units/models.py
+++ b/units/models.py
@@ -81,21 +81,33 @@ class Organization(models.Model):
     display_name = models.CharField(max_length=255, null=True, blank=True)
 
     def __str__(self):
-        return self.ext_org_name
+        return self.name
+
+    @property
+    def name(self):
+        return self.display_name if self.display_name else self.ext_org_name
 
 class College(models.Model):
     ext_college_name = models.CharField(max_length=255, null=False, blank=False)
     display_name = models.CharField(max_length=255, null=True, blank=True)
 
     def __str__(self):
-        return self.ext_college_name
+        return self.name
+
+    @property
+    def name(self):
+        return self.display_name if self.display_name else self.ext_college_name
 
 class Division(models.Model):
     ext_division_name = models.CharField(max_length=255, null=False, blank=False)
     display_name = models.CharField(max_length=255, null=True, blank=True)
 
     def __str__(self):
-        return self.ext_division_name
+        return self.name
+
+    @property
+    def name(self):
+        return self.display_name if self.display_name else self.ext_division_name
 
 class Department(models.Model):
     ext_department_id = models.CharField(max_length=10, null=False, blank=False)
@@ -103,7 +115,11 @@ class Department(models.Model):
     display_name = models.CharField(max_length=255, null=True, blank=True)
 
     def __str__(self):
-        return self.ext_department_name
+        return self.name
+
+    @property
+    def name(self):
+        return self.display_name if self.display_name else self.ext_department_name
 
 class Employee(models.Model):
     ext_employee_id = models.CharField(max_length=7, null=False, blank=False)

--- a/units/serializers.py
+++ b/units/serializers.py
@@ -1,0 +1,55 @@
+from rest_framework import serializers
+from units.models import *
+
+class OrganizationSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        fields = [
+            'ext_org_id',
+            'name'
+        ]
+        model = Organization
+
+class CollegeSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        fields = [
+            'name'
+        ]
+        model = College
+
+class DivisionSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        fields = [
+            'name'
+        ]
+        model = Division
+
+class DepartmentSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        fields = [
+            'ext_department_id',
+            'name'
+        ]
+        model = Department
+
+class EmployeeSerializer(serializers.ModelSerializer):
+    organization = OrganizationSerializer(many=False, read_only=True)
+    college = CollegeSerializer(many=False, read_only=True)
+    division = DivisionSerializer(many=False, read_only=True)
+    department = DepartmentSerializer(many=False, read_only=True)
+
+    class Meta:
+        fields = [
+            'ext_employee_id',
+            'first_name',
+            'last_name',
+            'prefix',
+            'department',
+            'organization',
+            'division',
+            'college'
+        ]
+        model = Employee


### PR DESCRIPTION
Resolves #284.

Adds `ext_employee_id`, `first_name`, `last_name`, `prefix`, `department`, `organization`, `division`, and `college` information to `employee_record` for each researcher on the researchers API endpoint. Also uses the name property to display the units models names in the admin so that display_names can be used if present.