### PR TITLE
Featured research terms; fixed sorting of research terms by researcher count

### DIFF
--- a/research/serializers.py
+++ b/research/serializers.py
@@ -211,27 +211,25 @@ class ResearcherSerializer(serializers.ModelSerializer):
 
     def get_research_terms(self, obj):
         retval = []
-        terms = obj.research_terms.annotate(
-            researcher_count=Count('researchers')
-        ).order_by('-researcher_count')[:10]
 
-        for term in terms:
-            retval.append(term.term_name)
-
+        terms = list(obj.research_terms.all())
+        if terms:
+            terms_sorted = sorted(list(terms), key=lambda obj: obj.researchers.count(), reverse=True)[:10]
+            retval = [t.term_name for t in terms_sorted]
 
         return retval
 
     def get_research_terms_featured(self, obj):
         retval = []
-        terms = obj.research_terms.annotate(
-            researcher_count=Count('researchers'),
+
+        terms = list(obj.research_terms.annotate(
             name_length=Length('term_name')
         ).filter(
             name_length__gt=1
-        ).order_by('-researcher_count')[:10]
+        ))
 
-        for term in terms:
-            retval.append(term.term_name)
-
+        if terms:
+            terms_sorted = sorted(list(terms), key=lambda obj: obj.researchers.count(), reverse=True)[:10]
+            retval = [t.term_name for t in terms_sorted]
 
         return retval

--- a/research/serializers.py
+++ b/research/serializers.py
@@ -1,4 +1,3 @@
-from django.db.models import Count
 from django.db.models.functions import Length
 
 from rest_framework import serializers
@@ -214,7 +213,7 @@ class ResearcherSerializer(serializers.ModelSerializer):
 
         terms = list(obj.research_terms.all())
         if terms:
-            terms_sorted = sorted(list(terms), key=lambda obj: obj.researchers.count(), reverse=True)[:10]
+            terms_sorted = sorted(terms, key=lambda obj: obj.researchers.count(), reverse=True)[:10]
             retval = [t.term_name for t in terms_sorted]
 
         return retval
@@ -229,7 +228,7 @@ class ResearcherSerializer(serializers.ModelSerializer):
         ))
 
         if terms:
-            terms_sorted = sorted(list(terms), key=lambda obj: obj.researchers.count(), reverse=True)[:10]
+            terms_sorted = sorted(terms, key=lambda obj: obj.researchers.count(), reverse=True)[:10]
             retval = [t.term_name for t in terms_sorted]
 
         return retval


### PR DESCRIPTION
- Added a new `research_terms_featured` field to Researcher API results, which provides a more filtered set of research terms suitable for importing into WordPress.  Currently, these featured terms are limited to terms at least two characters long.
- Updated sorting of researcher terms to perform sorting after fetching, since `obj.research_terms.annotate(researcher_count=Count('researchers'))` was returning the number of times the given term was assigned to _that researcher_, and not to _all researchers_ (and would always return 1).