### PR TITLE
Research Term View

### DIFF
--- a/research/serializers.py
+++ b/research/serializers.py
@@ -149,9 +149,19 @@ class ClinicalTrialSerializer(serializers.ModelSerializer):
         model = ClinicalTrial
 
 class ResearchTermSerializer(serializers.ModelSerializer):
+    researcher_count = serializers.SerializerMethodField()
+
     class Meta:
-        fields = '__all__'
+
+        fields = (
+            'id',
+            'term_name',
+            'researcher_count'
+        )
         model = ResearchTerm
+
+    def get_researcher_count(self, obj):
+        return obj.researchers.count()
 
 class ResearcherSerializer(serializers.ModelSerializer):
     teledata_record = StaffContactSerializer(many=False, read_only=True)
@@ -218,16 +228,6 @@ class ResearcherSerializer(serializers.ModelSerializer):
         )
         model = Researcher
 
-
-    def get_featured_terms(self, obj):
-        retval = []
-
-        terms = list(obj.research_terms.all())
-        if terms:
-            terms_sorted = sorted(terms, key=lambda obj: obj.researchers.count(), reverse=True)[:10]
-            retval = [t.term_name for t in terms_sorted]
-
-        return retval
 
     def get_research_terms_featured(self, obj):
         retval = []

--- a/research/serializers.py
+++ b/research/serializers.py
@@ -5,9 +5,6 @@ from research.models import *
 from teledata.serializers import StaffContactSerializer
 from units.serializers import EmployeeSerializer
 
-from django.db.models import Count
-from django.db.models.functions import Length
-
 class ResearcherEducationSerializer(serializers.ModelSerializer):
     class Meta:
         fields = '__all__'

--- a/research/urls.py
+++ b/research/urls.py
@@ -42,5 +42,9 @@ urlpatterns = [
     url(r'^researchers/(?P<id>\d+)/trials/$',
         ClinicalTrialListView.as_view(),
         name='api.researcher.trials.list'
+    ),
+    url(r'^researchers/(?P<id>\d+)/terms/$',
+        ResearchTermListView.as_view(),
+        name='api.researcher.terms.list'
     )
 ]

--- a/research/views.py
+++ b/research/views.py
@@ -105,4 +105,8 @@ class ResearchTermListView(generics.ListAPIView):
     def get_queryset(self):
         researcher_id = self.kwargs['id'] if 'id' in list(self.kwargs.keys()) else None
         if researcher_id:
-            return ResearchTerm.objects.filter(researchers=researcher_id).order_by('term_name')
+            return ResearchTerm.objects.annotate(
+                researcher_count=Count('researchers')
+            ).filter(
+                researchers=researcher_id
+            ).order_by('-researcher_count')

--- a/research/views.py
+++ b/research/views.py
@@ -97,3 +97,12 @@ class ClinicalTrialListView(generics.ListAPIView):
             return ClinicalTrial.objects.filter(researchers=researcher_id).order_by('-start_date')
 
         return None
+
+class ResearchTermListView(generics.ListAPIView):
+    lookup_field = 'id'
+    serializer_class = ResearchTermSerializer
+
+    def get_queryset(self):
+        researcher_id = self.kwargs['id'] if 'id' in list(self.kwargs.keys()) else None
+        if researcher_id:
+            return ResearchTerm.objects.filter(researchers=researcher_id).order_by('term_name')


### PR DESCRIPTION
Enhancements:
* To simplify the primary researchers view, `research_terms` is now being hyperlinked to specific view which lists all of the research terms for a specific researcher: `/research/researcher/<id>/terms/`. This should reduce the amount of data needed to represent each record, while still providing a place to retrieve the information.