### PR TITLE
Added serializer for researchers that includes some basic information

### DIFF
--- a/research/serializers.py
+++ b/research/serializers.py
@@ -5,12 +5,27 @@ from research.models import *
 from teledata.serializers import StaffContactSerializer
 from units.serializers import EmployeeSerializer
 
+class ResearcherSimpleSerializer(serializers.ModelSerializer):
+    employee_id = serializers.CharField(source='employee_record.ext_employee_id')
+
+    class Meta:
+        fields = (
+            'id',
+            'id',
+            'orcid_id',
+            'name_formatted_title',
+            'name_formatted_no_title',
+            'employee_id'
+        )
+        model = Researcher
+
 class ResearcherEducationSerializer(serializers.ModelSerializer):
     class Meta:
         fields = '__all__'
         model = ResearcherEducation
 
 class BookSerializer(serializers.ModelSerializer):
+    researchers = ResearcherSimpleSerializer(many=True, read_only=True)
 
     class Meta:
         fields = [
@@ -26,6 +41,7 @@ class BookSerializer(serializers.ModelSerializer):
         model = Book
 
 class ArticleSerializer(serializers.ModelSerializer):
+    researchers = ResearcherSimpleSerializer(many=True, read_only=True)
 
     class Meta:
         fields = [
@@ -43,6 +59,7 @@ class ArticleSerializer(serializers.ModelSerializer):
         model = Article
 
 class BookChapterSerializer(serializers.ModelSerializer):
+    researchers = ResearcherSimpleSerializer(many=True, read_only=True)
 
     class Meta:
         fields = [
@@ -60,6 +77,7 @@ class BookChapterSerializer(serializers.ModelSerializer):
         model = BookChapter
 
 class ConferenceProceedingSerializer(serializers.ModelSerializer):
+    researchers = ResearcherSimpleSerializer(many=True, read_only=True)
 
     class Meta:
         fields = [
@@ -77,6 +95,7 @@ class ConferenceProceedingSerializer(serializers.ModelSerializer):
         model = ConferenceProceeding
 
 class GrantSerializer(serializers.ModelSerializer):
+    researchers = ResearcherSimpleSerializer(many=True, read_only=True)
 
     class Meta:
         fields = [
@@ -96,6 +115,7 @@ class GrantSerializer(serializers.ModelSerializer):
         model = Grant
 
 class HonorificAwardSerializer(serializers.ModelSerializer):
+    researchers = ResearcherSimpleSerializer(many=True, read_only=True)
 
     class Meta:
         fields = [
@@ -110,6 +130,7 @@ class HonorificAwardSerializer(serializers.ModelSerializer):
         model = HonorificAward
 
 class PatentSerializer(serializers.ModelSerializer):
+    researchers = ResearcherSimpleSerializer(many=True, read_only=True)
 
     class Meta:
         fields = [
@@ -127,6 +148,7 @@ class PatentSerializer(serializers.ModelSerializer):
         model = Patent
 
 class ClinicalTrialSerializer(serializers.ModelSerializer):
+    researchers = ResearcherSimpleSerializer(many=True, read_only=True)
 
     class Meta:
         fields = [

--- a/research/serializers.py
+++ b/research/serializers.py
@@ -11,7 +11,6 @@ class ResearcherSimpleSerializer(serializers.ModelSerializer):
     class Meta:
         fields = (
             'id',
-            'id',
             'orcid_id',
             'name_formatted_title',
             'name_formatted_no_title',


### PR DESCRIPTION
Enhancements:
* Adds additional meta data to the researcher record on each published work. Instead of just the internal ID, the ID, ORCID, formatted name, formatted name with title _and_ most importantly the employee ID are listed. This will allow us to match up related researchers when importing into WordPress.