### PR TITLE
Academic Term Nonsense

### DIFF
--- a/programs/models.py
+++ b/programs/models.py
@@ -350,7 +350,9 @@ class AcademicTerm(models.Model):
 
     @property
     def year_as_str(self):
-        return self.full_name_split[1]
+        if len(self.full_name_split) > 1:
+            return self.full_name_split[1]
+        return "9999"
 
     @property
     def year(self):


### PR DESCRIPTION
Bug Fixes:
* It's possible for an academic term to be entered in our source system that does not match the required schema of `<Semester> <Year>`, so this checks to make sure the split full name has two elements before trying to access it. If it does not, we assume it's a nonsense value and return the year 9999 as the start term.