### PR TITLE
Description Excerpts

### DIFF
--- a/programs/models.py
+++ b/programs/models.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 
 
+from pydoc import describe
+from typing import Optional
+from typing_extensions import Self
 from django.db import models
 from django_mysql.models import ListTextField
 import calendar
 import re
 
 from django.conf import settings
+from django.utils.text import Truncator
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from rest_framework.authtoken.models import Token
@@ -14,6 +18,8 @@ from rest_framework.authtoken.models import Token
 from units.models import Unit
 from units.models import College as UnitCollege
 from units.models import Department as UnitDepartment
+
+from bs4 import BeautifulSoup
 
 # Create your models here.
 
@@ -221,12 +227,22 @@ class ProgramProfileType(models.Model):
     def __unicode__(self):
         return self.name
 
+class ProgramDescriptionTypeManager(models.Manager):
+
+    @property
+    def excerpt_description_type(self) -> Optional[Self]:
+        try:
+            return self.get(name=settings.EXCERPT_PROFILE_SOURCE)
+        except ProgramDescription.DoesNotExist:
+            return None
+
 
 class ProgramDescriptionType(models.Model):
     """
     Types of program descriptions, e.g. Main Site, UCF Online, Promotion
     """
     name = models.CharField(max_length=255, null=False, blank=False)
+    objects = ProgramDescriptionTypeManager()
 
     def __str__(self):
         return self.name
@@ -493,6 +509,16 @@ class Program(models.Model):
 
     def __unicode__(self):
         return self.name
+
+    @property
+    def excerpt(self) -> str:
+        try:
+            desc = self.descriptions.get(description_type=ProgramDescriptionType.objects.excerpt_description_type)
+            soup = BeautifulSoup(desc.description, features='lxml')
+            return Truncator(soup.get_text()).words(25, ' ...')
+
+        except ProgramDescription.DoesNotExist:
+            return '';
 
     @property
     def program_code(self):

--- a/programs/models.py
+++ b/programs/models.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
-from pydoc import describe
-from typing import Optional
-from typing_extensions import Self
 from django.db import models
 from django_mysql.models import ListTextField
 import calendar
@@ -230,7 +226,7 @@ class ProgramProfileType(models.Model):
 class ProgramDescriptionTypeManager(models.Manager):
 
     @property
-    def excerpt_description_type(self) -> Optional[Self]:
+    def excerpt_description_type(self):
         try:
             return self.get(name=settings.EXCERPT_PROFILE_SOURCE)
         except ProgramDescription.DoesNotExist:

--- a/programs/models.py
+++ b/programs/models.py
@@ -228,7 +228,7 @@ class ProgramDescriptionTypeManager(models.Manager):
     @property
     def excerpt_description_type(self):
         try:
-            return self.get(name=settings.EXCERPT_PROFILE_SOURCE)
+            return self.get(name=settings.EXCERPT_DESCRIPTION_TYPE_SOURCE)
         except ProgramDescription.DoesNotExist:
             return None
 

--- a/programs/serializers.py
+++ b/programs/serializers.py
@@ -421,6 +421,11 @@ class ProgramSerializer(DynamicFieldSetMixin, serializers.ModelSerializer):
     )
     start_term = AcademicTermSerializer(many=False, read_only=True)
 
+    excerpt = serializers.SerializerMethodField()
+
+    def get_excerpt(self, obj: Program):
+        return obj.excerpt
+
     class Meta:
         fields = (
             'id',
@@ -451,7 +456,8 @@ class ProgramSerializer(DynamicFieldSetMixin, serializers.ModelSerializer):
             'valid',
             'has_locations',
             'active',
-            'start_term'
+            'start_term',
+            'excerpt'
         )
         fieldsets = {
             "identifiers": "id,name,plan_code,subplan_code,cip_code,parent_program",

--- a/settings_local.tmpl.py
+++ b/settings_local.tmpl.py
@@ -190,6 +190,8 @@ PROGRAM_PROFILE = [
     }
 ]
 
+EXCERPT_PROFILE_SOURCE = 'Source Catalog Description'
+
 # Default program application deadline data to load during the
 # application deadline importer against all programs (by career, level):
 PROGRAM_APPLICATION_DEADLINES = [

--- a/settings_local.tmpl.py
+++ b/settings_local.tmpl.py
@@ -190,7 +190,7 @@ PROGRAM_PROFILE = [
     }
 ]
 
-EXCERPT_PROFILE_SOURCE = 'Source Catalog Description'
+EXCERPT_DESCRIPTION_TYPE_SOURCE = 'Source Catalog Description'
 
 # Default program application deadline data to load during the
 # application deadline importer against all programs (by career, level):


### PR DESCRIPTION
Enhancements:
* Adds the `excerpt` field to programs.
* Adds a setting for determining which program description should be used to generate the excerpt.
* Adds the `excerpt` field to the program serializer.

Note:
* We may need to come up to cache the excerpt so we're not having to generate it on the fly each API call. It would be nice to do some benchmarking to see how much this is slowing down the API calls compared to QA/PROD.
* We also may need to make the number of words configurable.