### PR TITLE
Better Catalog Matches

### DIFF
--- a/programs/utilities/catalog_match.py
+++ b/programs/utilities/catalog_match.py
@@ -244,7 +244,10 @@ class MatchableProgram(object):
             (object|None): Highest-scoring CatalogEntry match, or None
         """
         if self.has_matches:
-            return max(self.matches, key=itemgetter(0))
+            max_match = max(self.matches, key=itemgetter(0))
+            code = max_match[1].data['code']
+            similar_matches = [x for x in self.matches if x[1].data['code'] == code]
+            return max(similar_matches, key=lambda x: x[1].data['created'])
         else:
             return None
 


### PR DESCRIPTION
Bug Fixes:
* Currently, it is possible for program to match with catalog entries from previous years. As a temporary fix, we are now getting the best match, then filtering all catalog entries to only those with the same `code` value as the best match, and then choosing the match with the most recent created date.