### PR TITLE
Lookup Bug

### DIFF
--- a/programs/serializers.py
+++ b/programs/serializers.py
@@ -445,7 +445,7 @@ class ProgramSerializer(DynamicFieldSetMixin, serializers.ModelSerializer):
             return None
 
         try:
-            subarea_cip = CIP.objects.get(code=f"{obj.current_cip.area}.{obj.current_cip.subarea}", version=settings.CIP_CURRENT_VERSION)
+            subarea_cip = CIP.objects.get(code=f"{obj.current_cip.area}.{str(obj.current_cip.subarea).zfill(2)}", version=settings.CIP_CURRENT_VERSION)
             cip_name = subarea_cip.name.title()
             return cip_name
         except CIP.DoesNotExist:


### PR DESCRIPTION
In our recently added `subarea_of_interest` field, CIPs that have single digits for their subarea, i.e. `02`, `03`, etc., were not being returned when queried. The string format we were using wasn't taking into account the fact that those numbers need to be zero padded. So for example, the Accounting (BSBA) program has a CIP of `52.0301`. When the string was formatted, it was looking up a code of `52.3` instead of `52.03`. I've corrected this by casting the subarea to a string, and then calling the `zfill` (zero fill) function and specifying it should have a length of 2 digits.

Changes can be reviewed in DEV by looking at program ID 2.