### PR TITLE
Another quick fix to CIP processing

### DIFF
--- a/programs/models.py
+++ b/programs/models.py
@@ -143,6 +143,34 @@ class CIP(models.Model):
 
         super(CIP, self).save(*args, **kwargs)
 
+    @property
+    def area_code_str(self) -> str:
+        """
+        Returns the CIP area code as a string with a
+        leading zero if necessary. Returns an empty
+        string if the code is not set.
+        """
+        return str(self.area).zfill(2) if self.area is not None else ""
+    
+    @property
+    def subarea_code_str(self) -> str:
+        """
+        Returns the CIP subarea code as a string with a
+        leading zero if necessary. Returns an empty
+        string if the code is not set.
+        """
+        return str(self.subarea).zfill(2) if self.subarea is not None else ""
+    
+    @property
+    def precise_code_str(self) -> str:
+        """
+        Returns the CIP precise code as a string with a
+        leading zero if necessary. Returns an empty
+        string if the code is not set.
+        """
+        return str(self.precise).zfill(2) if self.precise is not None else ""
+
+
     def __unicode__(self):
         return "{0} - {1} ({2})".format(
             str(self.code),

--- a/programs/serializers.py
+++ b/programs/serializers.py
@@ -434,7 +434,7 @@ class ProgramSerializer(DynamicFieldSetMixin, serializers.ModelSerializer):
             return None
 
         try:
-            top_level_cip = CIP.objects.get(code=obj.current_cip.area, version=settings.CIP_CURRENT_VERSION)
+            top_level_cip = CIP.objects.get(code=obj.current_cip.area_code_str, version=settings.CIP_CURRENT_VERSION)
             cip_name = top_level_cip.name.title()
             return cip_name
         except CIP.DoesNotExist:
@@ -445,7 +445,7 @@ class ProgramSerializer(DynamicFieldSetMixin, serializers.ModelSerializer):
             return None
 
         try:
-            subarea_cip = CIP.objects.get(code=f"{obj.current_cip.area}.{str(obj.current_cip.subarea).zfill(2)}", version=settings.CIP_CURRENT_VERSION)
+            subarea_cip = CIP.objects.get(code=f"{obj.current_cip.area_code_str}.{obj.current_cip.subarea_code_str}", version=settings.CIP_CURRENT_VERSION)
             cip_name = subarea_cip.name.title()
             return cip_name
         except CIP.DoesNotExist:


### PR DESCRIPTION
All of the subcodes (area, subarea, and the precise codes) need to be zero padded. So I went ahead and created 3 new properties to return those properly zero padded and as strings, and updated our view to use these new properties.