### PR TITLE
Added Font-awesome 6 pro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ node_modules
 
 # SSH Support
 .localcerts/
+
+# env
+.env

--- a/core/forms.py
+++ b/core/forms.py
@@ -6,4 +6,3 @@ class CommunicatorProgramForm(forms.Form):
     custom_description = forms.CharField(widget=Wysiwyg(), required=False)
     jobs = forms.CharField()
     jobs_source = forms.CharField(widget=forms.Textarea(attrs={ 'rows': 5 }), required=True)
-    highlight_description1 = forms.CharField(widget=forms.Textarea(attrs= { 'rows' : 4 }))

--- a/core/forms.py
+++ b/core/forms.py
@@ -6,3 +6,4 @@ class CommunicatorProgramForm(forms.Form):
     custom_description = forms.CharField(widget=Wysiwyg(), required=False)
     jobs = forms.CharField()
     jobs_source = forms.CharField(widget=forms.Textarea(attrs={ 'rows': 5 }), required=True)
+    highlight_description1 = forms.CharField(widget=forms.Textarea(attrs= { 'rows' : 4 }))

--- a/requirements.txt
+++ b/requirements.txt
@@ -121,6 +121,9 @@ urllib3==1.26.16
     #   requests
 xmlschema==2.3.1
     # via pysaml2
+--extra-index-url https://dl.fontawesome.com/TOKEN/fontawesome-pro/python/simple/
+fontawesomepro==6.5.2
+    # Fontawesomepro
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/settings.py
+++ b/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'widget_tweaks',
     'django_saml2_auth',
     'auditlog',
+    'fontawesomepro',
 
     # Local
     'programs',

--- a/templates/base-bootstrap.html
+++ b/templates/base-bootstrap.html
@@ -9,7 +9,19 @@
     {% block css %}
     <!-- Athena CSS -->
     <link rel="stylesheet" href="{% static 'css/style.min.css' %}">
+    <!-- FontAwesomePro 6 -->
+    <link href="{% static 'fontawesomepro/css/fontawesome.css' %}" rel="stylesheet" type="text/css">
+    <link href="{% static 'fontawesomepro/css/solid.css' %}" rel="stylesheet" type="text/css">
+    <link href="{% static 'fontawesomepro/css/sharp-solid.css' %}" rel="stylesheet" type="text/css">
+    <link href="{% static 'fontawesomepro/css/sharp-regular.css' %}" rel="stylesheet" type="text/css">
+    <link href="{% static 'fontawesomepro/css/brands.css' %}" rel="stylesheet" type="text/css">
     {% endblock %}
+    <!-- FontAwesomePro 6 svg -->
+    <script src="{% static 'fontawesomepro/js/fontawesome.js' %}"></script>
+    <script src="{% static 'fontawesomepro/js/solid.js' %}"></script>
+    <script src="{% static 'fontawesomepro/js/sharp-solid.js' %}"></script>
+    <script src="{% static 'fontawesomepro/js/sharp-regular.js' %}"></script>
+    <script src="{% static 'fontawesomepro/js/brands.js' %}"></script>
   </head>
   <body data-spy="scroll" data-target="#sidebar">
     <header>


### PR DESCRIPTION
 To add Font Awesome 6 Pro to your Django project using Django packages, follow these steps:

1. Replace the placeholder TOKEN with your actual Font Awesome 6 Pro token to download the packages.
2. Run the following command to install the packages: pip3 install -r requirements.txt
3. Font Awesome 6 Pro will be available for use in your project. To include it in your HTML templates, add the necessary <link> or <script> tags to the <head> section of your base template file. In this case added these tags to the base-bootstrap.html file.