### PR TITLE
Positions scraper

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url, include
+from django.urls import path
 from django.urls import reverse_lazy
 from django.views.generic import TemplateView
 from django.contrib.auth.decorators import login_required
@@ -38,6 +39,10 @@ urlpatterns = [
         r'^manager/search/$',
         SearchView.as_view(template_name='search.html'),
         name='search'
+    ),
+    url(r'^api/v1/positions/$',
+        OpenJobListView.as_view(),
+        name='api.positions.list'
     ),
     url(
         r'^settings/$',

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url, include
-from django.urls import path
 from django.urls import reverse_lazy
 from django.views.generic import TemplateView
 from django.contrib.auth.decorators import login_required

--- a/core/views.py
+++ b/core/views.py
@@ -592,6 +592,12 @@ class UsageReportView(LoginRequiredMixin, TitleContextMixin, TemplateView):
 
 class OpenJobListView(APIView):
     def get(self, request):
+        # Parameters recieving
+        limit = int(request.query_params.get('limit', 10))
+        offset = int(request.query_params.get('offset', 0))
+
+        print(limit, offset)
+
         url = "https://jobs.ucf.edu/jobs/search"
         response = requests.get(url)
         soup = BeautifulSoup(response.content, 'html.parser')  # Specify the parser
@@ -608,11 +614,13 @@ class OpenJobListView(APIView):
                 href = a_tag.get('href')
                 title = a_tag.get_text(strip=True)
 
-                # Remove the base URL part
                 if href.startswith(base_url):
                     href = href[len(base_url):]
 
                 jobs.append({'title': title, 'externalPath': href})
+
+        # apply offset and limit to the jobs array
+        jobs = jobs[offset: offset+limit]
 
         # Format the response
         response_data = {'jobPostings': jobs}

--- a/core/views.py
+++ b/core/views.py
@@ -596,8 +596,6 @@ class OpenJobListView(APIView):
         limit = int(request.query_params.get('limit', 10))
         offset = int(request.query_params.get('offset', 0))
 
-        print(limit, offset)
-
         url = "https://jobs.ucf.edu/jobs/search"
         response = requests.get(url)
         soup = BeautifulSoup(response.content, 'html.parser')  # Specify the parser

--- a/core/views.py
+++ b/core/views.py
@@ -599,7 +599,7 @@ class OpenJobListView(APIView):
         url = base_url + "/search"
 
         try:
-            response = requests.get(url, timeout=30)
+            response = requests.get(url, timeout=10)
             # Raises HTTPError for bad responses
             response.raise_for_status()
         except requests.exceptions.RequestException as e:

--- a/settings_local.tmpl.py
+++ b/settings_local.tmpl.py
@@ -433,3 +433,6 @@ SAML2_AUTH = {
     },
     'ASSERTION_URL': '{assertion_url}', # Custom URL to validate incoming SAML requests against
 }
+
+# Jobs scraper configuration item
+JOBS_SCRAPE_BASE_URL = 'https://jobs.ucf.edu/jobs'


### PR DESCRIPTION
- Added logic to scrape the first page titles and URLs from https://jobs.ucf.edu/jobs/search. (title, externalpath)
- Registered the REST API gateway at http://{domain}/api/v1/positions/.
- By default, it returns the 10 latest jobs when using the [ucf-jobs] shortcode in WordPress.
- We are able to receive offset and limit parameters; by default, offset is set to 0 and limit is set to 10.