### PR TITLE
Current CIP Property Bug

### DIFF
--- a/programs/models.py
+++ b/programs/models.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 from django.db import models
 from django_mysql.models import ListTextField
 import calendar
@@ -18,6 +19,8 @@ from auditlog.registry import auditlog
 from auditlog.models import AuditlogHistoryField
 
 from bs4 import BeautifulSoup
+
+logger = logging.getLogger()
 
 # Create your models here.
 
@@ -581,6 +584,11 @@ class Program(models.Model):
     def current_cip(self) -> CIP:
         try:
             return self.cip.get(version=settings.CIP_CURRENT_VERSION)
+        except CIP.MultipleObjectsReturned:
+            # If this happens, there is something wrong with our data.
+            # That said, we'd prefer not to throw a big fat error.
+            logger.error(f"The program {self.name} has two CIPS for CIP version {settings.CIP_CURRENT_VERSION}!")
+            return None
         except CIP.DoesNotExist:
             return None
 


### PR DESCRIPTION
Our data model for `Program`s includes a property called `current_cip` that is supposed to return the (singular) `CIP` for a program based on what the current CIP version we're using is. Our various imports and processes are supposed to ensure there is only 1 CIP assigned for each version at a time. However, there seems to be a loophole somewhere, and the property had no logic to account for if there were multiple CIPs assigned for a particular version.

This pull request remedies that by returning `None` if multiple CIPs are returned. In a future pull request, we'll either adjust the model to only allow one CIP per version - possibly by creating a compound unique key - or try to track down the loophole and close it.