### PR TITLE
Catalog Matching Logic Update

### DIFF
--- a/programs/utilities/catalog_match.py
+++ b/programs/utilities/catalog_match.py
@@ -1,5 +1,6 @@
 from operator import itemgetter
 from fuzzywuzzy import fuzz
+from datetime import datetime
 
 from programs.models import Level, Career, Program
 
@@ -294,8 +295,16 @@ class MatchableProgram(object):
         if self.has_matches:
             max_match = max(self.matches, key=itemgetter(0))
             code = max_match[1].data['code']
-            similar_matches = [x for x in self.matches if x[1].data['code'] == code]
-            return max(similar_matches, key=lambda x: x[1].data['created'])
+            similar_matches = [
+                x for x in self.matches
+                    if x[1].data['code'] == code
+                    and 'dateStart' in x[1].data
+                    and datetime.strptime(x[1].data['dateStart'], '%Y-%m-%d') < datetime.now()
+            ]
+            return max(
+                similar_matches,
+                key=lambda x: datetime.strptime(x[1].data['dateStart'], '%Y-%m-%d')
+            ) if len(similar_matches) > 0 else max_match
         else:
             return None
 


### PR DESCRIPTION
I've updated our matching logic to:
- Reject all catalog descriptions that don't have the `dateStart` field. This should weed out most of the older descriptions, and also is just necessary as there's no other way to tell if a description is current.
- When filtering down the candidates, I reject any descriptions who's `dateStart` is greater than today. This should remove any catalog entries for future catalogs that are not yet published.
- I then ask for the max `dateStart` value available in the remaining candidates. This should give us the _most recent_ catalog entry, that's not a future entry.