### PR TITLE
Added API endpoints for CRUD operations on quotes

### DIFF
--- a/marketing/models.py
+++ b/marketing/models.py
@@ -16,6 +16,6 @@ class Quote(models.Model):
             return self.quote_text
 
     @property
-    def titles_formatted(self):
+    def source_formatted(self):
         pattern = r'(.*[\’\']\d{2}([a-zA-Z.]+)?)'
-        return re.sub(pattern, '<strong>\g<1></strong>', self.title)
+        return re.sub(pattern, '<strong>\g<1></strong>', f"{self.source} {self.titles}")

--- a/marketing/parsers.py
+++ b/marketing/parsers.py
@@ -1,0 +1,21 @@
+from rest_framework import parsers
+
+class MultiPartJSONParser(parsers.MultiPartParser):
+    def parse(self, stream, *args, **kwargs):
+        data = super().parse(stream, *args, **kwargs)
+
+        mutable_data = data.data.copy()
+        unmarshalled_blob_names = []
+        json_parser = parsers.JSONParser()
+
+        for name, blob in data.files.items():
+            if blob.content_type == 'application/json' and name not in data.data:
+                mutable_data[name] = json_parser.parse(blob)
+                unmarshalled_blob_names.append(name)
+
+        for name in unmarshalled_blob_names:
+            del data.files[name]
+
+        data.data = mutable_data
+
+        return data

--- a/marketing/serializers.py
+++ b/marketing/serializers.py
@@ -1,0 +1,17 @@
+from rest_framework import serializers
+
+from marketing.models import Quote
+
+class QuoteSerializer(serializers.ModelSerializer):
+    source_formatted = serializers.ReadOnlyField()
+
+    class Meta:
+        model = Quote
+        fields = (
+            'id',
+            'quote_text',
+            'source',
+            'titles',
+            'image',
+            'source_formatted'
+        )

--- a/marketing/urls.py
+++ b/marketing/urls.py
@@ -1,0 +1,18 @@
+from django.conf.urls import url, include
+
+from marketing.views import *
+
+urlpatterns = [
+    url(r'^quotes/$',
+        QuoteListView.as_view(),
+        name='api.marketing.quotes.list'
+    ),
+    url(r'^quotes/(?P<id>\d+)/$',
+        QuoteRetrieveUpdateDestroyView.as_view(),
+        name='api.marketing.quotes.single'
+    ),
+    url(r'^quotes/create/$',
+        QuoteCreateView.as_view(),
+        name='api.marketing.quotes.create'
+    ),
+]

--- a/marketing/views.py
+++ b/marketing/views.py
@@ -1,3 +1,21 @@
-from django.shortcuts import render
+from rest_framework import generics
+from rest_framework.parsers import JSONParser
+
+from marketing.models import *
+from marketing.serializers import *
+from marketing.parsers import MultiPartJSONParser
 
 # Create your views here.
+class QuoteListView(generics.ListAPIView):
+    queryset = Quote.objects.all()
+    serializer_class = QuoteSerializer
+
+class QuoteCreateView(generics.CreateAPIView):
+    serializer_class = QuoteSerializer
+
+class QuoteRetrieveUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Quote.objects.all()
+    lookup_field = 'id'
+    serializer_class = QuoteSerializer
+    parser_classes = (MultiPartJSONParser,JSONParser,)
+

--- a/urls.py
+++ b/urls.py
@@ -28,11 +28,14 @@ urlpatterns = [
     url(r'^api/v1/images/',
         include('images.urls')
         ),
-    url(r'^api/v1/',
-        include('programs.urls')
-        ),
     url(r'^api/v1/research/',
         include('research.urls')
+        ),
+    url(r'^api/v1/marketing/',
+        include('marketing.urls')
+        ),
+    url(r'^api/v1/',
+        include('programs.urls')
         ),
     url(r'^api-auth/',
         include('rest_framework.urls')


### PR DESCRIPTION
- Renamed the `titles_formatted` field to `source_formatted` which returns the source and titles formatted for HTML.
- Adds the Quote API endpoints. I will be fully documenting the API in this pull request for review. We will eventually need to put this documentation into the home page or find some other place to document the API.

For some of the following examples, you will need to provide an API key in the request. The easiest way to provide this key is to pass it as a query parameter:

`https://<search-service-url>/api/v1/marketing/quotes/?key=yourreallylongapikey`

Additionally, the `Content-type` header for most of the requests will be `application/json`, but for the create and update views, when passing a file, the `Content-type` needs to be set to `multipart/form-data`. I will explain this further for those endpoints.

## All Quotes

**URL: `https://<search-service-url>/api/v1/marketing/quotes/`**
**Request Method: GET**

This will retrieve all quotes. There is currently no filtering or searching functionality. This will need to be added in a future pull request.

## Create Quote

**URL: `https://<search-service-url>/api/v1/marketing/quotes/create/`**
**Request Method: POST**

This will create a single quote, and can be access with two different content-types. We can create the quote object without an image using the `application/json` content-type. To do so, call a POST request to this endpoint, with the `application/json` content-type, and pass the following parameters:

```json
"quote_text": "Your quote text",
"source": "The name or source of the person being quoted",
"titles": "The accolades or position of the person being quoted"
```

To upload a file to this endpoint, you will need to pass in the data as form data, and use the content-type `multipart/form-data`. Each form field is passed using the same name as above, and the image file should be passed using the field name `image`. Below is an example of the request fields in Insomnia.

![quotes-update-with-file](https://github.com/user-attachments/assets/329eedfc-4c88-4be0-9868-433bf823103c)

## Retrieve Single Quote

**URL: `https://<search-service-url>/api/v1/marketing/quotes/:id/`**
**Request Method: GET**

This will retrieve a single quote by ID. 

## Updated Single Quote

**URL: `https://<search-service-url>/api/v1/marketing/quotes/:id/`**
**Request Methods: PUT or PATCH**

This will update a single quote, and can be accessed using two different content-types. You can edit all the fields other than `image` using the `application/json` content-type. When using the `PUT` method, all fields must be provided. Any fields that are not provided will be set to null. When using the `PATCH` method, only the fields provided will be updated.

```json
"quote_text": "Your quote text",
"source": "The name or source of the person being quoted",
"titles": "The accolades or position of the person being quoted"
```

To upload a file to this endpoint, you will need to pass in the data as form data, and use the content-type `multipart-form-data`. Each form field is passed using the name as above, and the image file should be passed using the field name `image`. Below is an example of the request in Insomnia:

![quotes-patch-with-file](https://github.com/user-attachments/assets/ff95fc3f-52a7-4c62-9f0b-3e75d1855f27)

## Delete Single Quote

**URL: https://<search-service-url>/api/v1/marketing/quotes/:id/`**
**Request Method: DELETE**

This will delete a single quote. No additional data is needed for this request.
