### PR TITLE
Teledata Filter Adjustments

### DIFF
--- a/teledata/filters.py
+++ b/teledata/filters.py
@@ -17,11 +17,11 @@ class CombinedTeledataFilter(django_filters.FilterSet):
 
     class Meta:
         model = CombinedTeledata
-        fields = (
-            'pkid',
-            'id',
-            'alpha',
-            'name',
-            'use',
-            'active'
-        )
+        fields = {
+            'pkid': ['exact'],
+            'id': ['exact', 'in'],
+            'alpha': ['exact'],
+            'name': ['exact', 'icontains'],
+            'from_table': ['exact', 'in'],
+            'active': ['exact']
+        }

--- a/templates/home.html
+++ b/templates/home.html
@@ -101,6 +101,13 @@
               </tr>
               <tr>
                 <td>
+                  <code>from_table</code>
+                </td>
+                <td>Limits the results to a specific object type. Additionally, <code>from_table__in</code> can be used to retrieve results from more than one table.</td>
+                <td><code>staff</code>, <code>departments</code> and <code>organizations</code></td>
+              </tr>
+              <tr>
+                <td>
                   <code>alpha</code>
                 </td>
                 <td>Whether all records should be pulled for staff members or only the primary (alpha) record</td>


### PR DESCRIPTION
- Added the `from_table` field to the teledata filter so that we can use the built-in `__in` filter to search through multiple tables.
- Kept the `use` filter, since it is documented and needs to be kept for backwards compatibility just in case someone is using this API.
- Updated the documentation to reflect the new field.