### PR TITLE
Endpoint refinement

### DIFF
--- a/podcasts/serializers.py
+++ b/podcasts/serializers.py
@@ -8,9 +8,15 @@ from taggit.serializers import (
 
 from podcasts.models import (
     PodcastShow,
+    PodcastCategory,
     PodcastEpisodeHighlight,
     PodcastEpisode
 )
+
+class PodcastCategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        fields = '__all__'
+        model = PodcastCategory
 
 class PodcastShowSerializer(serializers.ModelSerializer):
     show_image = serializers.SerializerMethodField()
@@ -59,6 +65,9 @@ class PodcastEpisodeSimpleSerializer(serializers.ModelSerializer):
 
 
 class PodcastEpisodeSerializer(TaggitSerializer, serializers.ModelSerializer):
+    tags = TagListSerializerField(read_only=True)
+    category = PodcastCategorySerializer(read_only=True, many=False)
+
     highlights = PodcastEpisodeHighlightSerializer(
         many=True,
         read_only=True

--- a/podcasts/serializers.py
+++ b/podcasts/serializers.py
@@ -45,7 +45,7 @@ class PodcastEpisodeHighlightSerializer(serializers.ModelSerializer):
         model = PodcastEpisodeHighlight
 
 class PodcastEpisodeSimpleSerializer(serializers.ModelSerializer):
-    tags = TagListSerializerField()
+    tags = TagListSerializerField(read_only=True)
 
     class Meta:
         fields = (

--- a/podcasts/serializers.py
+++ b/podcasts/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django.urls import reverse
 
 from podcasts.models import (
     PodcastShow,
@@ -8,9 +9,16 @@ from podcasts.models import (
 
 class PodcastShowSerializer(serializers.ModelSerializer):
     show_image = serializers.SerializerMethodField()
+    episodes = serializers.SerializerMethodField()
 
     class Meta:
-        fields = '__all__'
+        fields = (
+            'id',
+            'title',
+            'description',
+            'show_image',
+            'episodes'
+        )
         model = PodcastShow
 
     def get_show_image(self, obj):
@@ -20,10 +28,28 @@ class PodcastShowSerializer(serializers.ModelSerializer):
             'thumbnail': obj.show_image_thumbnail.url if obj.show_image_thumbnail else None
         }
 
+    def get_episodes(self, obj):
+        return reverse(
+            'api.podcasts.details.episodelist',
+            args=[obj.id]
+        )
+
 class PodcastEpisodeHighlightSerializer(serializers.ModelSerializer):
     class Meta:
         fields = '__all__'
         model = PodcastEpisodeHighlight
+
+class PodcastEpisodeSimpleSerializer(serializers.ModelSerializer):
+    class Meta:
+        fields = (
+            'id',
+            'title',
+            'description',
+            # 'tags',
+            'category'
+        )
+        model = PodcastEpisode
+
 
 class PodcastEpisodeSerializer(serializers.ModelSerializer):
     highlights = PodcastEpisodeHighlightSerializer(

--- a/podcasts/serializers.py
+++ b/podcasts/serializers.py
@@ -1,6 +1,11 @@
 from rest_framework import serializers
 from django.urls import reverse
 
+from taggit.serializers import (
+    TaggitSerializer,
+    TagListSerializerField
+)
+
 from podcasts.models import (
     PodcastShow,
     PodcastEpisodeHighlight,
@@ -40,18 +45,20 @@ class PodcastEpisodeHighlightSerializer(serializers.ModelSerializer):
         model = PodcastEpisodeHighlight
 
 class PodcastEpisodeSimpleSerializer(serializers.ModelSerializer):
+    tags = TagListSerializerField()
+
     class Meta:
         fields = (
             'id',
             'title',
             'description',
-            # 'tags',
+            'tags',
             'category'
         )
         model = PodcastEpisode
 
 
-class PodcastEpisodeSerializer(serializers.ModelSerializer):
+class PodcastEpisodeSerializer(TaggitSerializer, serializers.ModelSerializer):
     highlights = PodcastEpisodeHighlightSerializer(
         many=True,
         read_only=True

--- a/podcasts/urls.py
+++ b/podcasts/urls.py
@@ -4,6 +4,7 @@ from podcasts.views import (
     PodcastShowListView,
     PodcastShowDetailView,
     PodcastEpisodeListView,
+    PodcastEpisodeSummaryView,
     PodcastShowEpisodeListView
 )
 
@@ -15,6 +16,10 @@ urlpatterns = [
     url(r'^episodes/$',
         PodcastEpisodeListView.as_view(),
         name='api.podcasts.episodelist'
+    ),
+    url(r'^episodes/(?P<id>\d+)/$',
+        PodcastEpisodeSummaryView.as_view(),
+        name='api.podcasts.episode.summary'
     ),
     url(r'^(?P<id>\d+)/$',
         PodcastShowDetailView.as_view(),

--- a/podcasts/views.py
+++ b/podcasts/views.py
@@ -9,13 +9,14 @@ from podcasts.models import (
 
 from podcasts.serializers import (
     PodcastShowSerializer,
-    PodcastEpisodeSerializer
+    PodcastEpisodeSerializer,
+    PodcastEpisodeSimpleSerializer
 )
 
 from podcasts.filters import (
     PodcastShowListFilter,
     PodcastEpisodeListFilter
-    )
+)
 
 # Create your views here.
 class PodcastShowListView(generics.ListAPIView):
@@ -37,7 +38,7 @@ class PodcastEpisodeListView(generics.ListAPIView):
 
 class PodcastShowEpisodeListView(generics.ListAPIView):
     lookup_field = 'id'
-    serializer_class = PodcastEpisodeSerializer
+    serializer_class = PodcastEpisodeSimpleSerializer
     filter_class = PodcastEpisodeListFilter
 
     def get_queryset(self):

--- a/podcasts/views.py
+++ b/podcasts/views.py
@@ -36,6 +36,12 @@ class PodcastEpisodeListView(generics.ListAPIView):
     serializer_class = PodcastEpisodeSerializer
     filter_class = PodcastEpisodeListFilter
 
+class PodcastEpisodeSummaryView(generics.RetrieveAPIView):
+    queryset = PodcastEpisode.objects.all()
+    lookup_field = 'id'
+    serializer_class = PodcastEpisodeSerializer
+
+
 class PodcastShowEpisodeListView(generics.ListAPIView):
     lookup_field = 'id'
     serializer_class = PodcastEpisodeSimpleSerializer


### PR DESCRIPTION
Updates:
- Added categories and tags to show and episode serializers (which adds them to the API endpoints)
- Started reducing the number of fields on certain endpoints. The idea behind this is for the endpoint that lists episodes for a show, not every piece of information about the episode is needed to list them out. That full detail is only needed on the episode detail API view, which would be used on the corresponding episode detail web view on the front end.
- There will be further refining of the endpoints to make sure they're meeting the need necessary and not providing more information than is needed (to keep the size of responses down and keep the frontend application fast).